### PR TITLE
Fix Cannot allocate memory error in stadalone.

### DIFF
--- a/src/kern/npf_conn.c
+++ b/src/kern/npf_conn.c
@@ -493,7 +493,7 @@ npf_conn_inspect(npf_cache_t *npc, const int di, int *error)
 	 * If this is multi-end state, then specially tag the packet
 	 * so it will be just passed-through on other interfaces.
 	 */
-	if (con->c_ifid == 0 && nbuf_add_tag(nbuf, NPF_NTAG_PASS) != 0) {
+	if (con->c_ifid == 0 && nbuf_add_tag(nbuf, NPF_NTAG_PASS) == ENOMEM) {
 		npf_conn_release(con);
 		*error = ENOMEM;
 		return NULL;


### PR DESCRIPTION
When npf is in standalone, nbuf_add_tag return automatically ENOTSUP, then *error is set to ENOMEM, which isn't what's happen, and base on the comment above, I guess npf should not automatically block any packet that arrive at this step.