### PR TITLE
Fix mutex_enter fail with no worker.

### DIFF
--- a/src/kern/npf_worker.c
+++ b/src/kern/npf_worker.c
@@ -148,9 +148,12 @@ void
 npf_worker_unregister(npf_t *npf, npf_workfunc_t func)
 {
 	const unsigned idx = npf->worker_id;
-	npf_worker_t *wrk = &npf_workers[idx];
+	npf_worker_t *wrk;
 	npf_t *instance;
 
+	if (!npf_worker_count)
+		return;
+	wrk = &npf_workers[idx];
 	mutex_enter(&wrk->worker_lock);
 	npf_worker_testset(wrk, func, NULL);
 	if ((instance = wrk->instances) == npf) {


### PR DESCRIPTION
When NPF_NO_GC is set, npf_worker_register is not call, so wrk->worker_lock is not initialized,
then when npf_worker_unregister is call, it fail.
Another workaround, would be to add a global variable in npf_conn which is set to 1 when there is
no garbage collector, then check this variable before calling npf_worker_*.