### PR TITLE
use iface name in npf_rule_create

### DIFF
--- a/dpdk/npf_dpdk_demo.c
+++ b/dpdk/npf_dpdk_demo.c
@@ -118,7 +118,7 @@ create_npf_config(void)
 	 * packets where either source or destination is 10.1.1.1 .
 	 */
 	rl = npf_rule_create(NULL, NPF_RULE_PASS | NPF_RULE_STATEFUL |
-	    NPF_RULE_IN | NPF_RULE_OUT, NULL);
+	    NPF_RULE_IN | NPF_RULE_OUT, "dpdk0");
 	assert(rl != NULL);
 	build_pcap_filter(rl, "host 10.1.1.1 and dst port 53");
 


### PR DESCRIPTION
as notice here: https://github.com/rmind/npf/pull/3#issuecomment-354350866.
npf need to call npf_ifmap_register in order to set the iface, which is call by passing iface name in npf_rule_create