### PR TITLE
Reduce the memory usage by optimising the connection state size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Some key features are:
   - Static (stateless) and dynamic (stateful) translation.
   - NAPT and other forms of port translation (e.g. port forwarding).
   - Inbound and outbound NAT as well as bi-directional NAT.
-  - Network-to-network translation, including NPTv6.
+  - Network-to-network translation, including NETMAP and NPTv6.
 - Tables for efficient IP sets, including the _longest prefix match_ support.
 - Application Level Gateways (e.g. to support traceroute).
 - NPF uses [BPF with just-in-time (JIT) compilation](https://github.com/rmind/bpfjit).

--- a/src/kern/Makefile
+++ b/src/kern/Makefile
@@ -51,8 +51,7 @@ endif
 
 OBJS=		$(shell grep ^file files.npf | cut -f2 | \
 		    sed 's/\(.*\)net\/npf\/\(.*\).c/\2.o/g' | \
-		    grep -v npf_os | grep -v npf_alg_ | \
-		    grep -v npf_ext_ | grep -v npf_ifaddr | \
+		    grep -v npf_os | grep -v npf_ext_ | grep -v npf_ifaddr | \
 		    grep -v if_npflog | grep -v lpm)
 
 OBJS+=		stand/bpf_filter.o

--- a/src/kern/files.npf
+++ b/src/kern/files.npf
@@ -22,6 +22,7 @@ file	net/npf/npf_tableset.c			npf
 file	net/npf/npf_if.c			npf
 file	net/npf/npf_inet.c			npf
 file	net/npf/npf_conn.c			npf
+file	net/npf/npf_connkey.c			npf
 file	net/npf/npf_conndb.c			npf
 file	net/npf/npf_state.c			npf
 file	net/npf/npf_state_tcp.c			npf

--- a/src/kern/npf.c
+++ b/src/kern/npf.c
@@ -173,12 +173,29 @@ npf_stats_collect(void *mem, void *arg, struct cpu_info *ci)
 	}
 }
 
+static void
+npf_stats_clear_cb(void *mem, void *arg, struct cpu_info *ci)
+{
+	uint64_t *percpu_stats = mem;
+
+	for (unsigned i = 0; i < NPF_STATS_COUNT; i++) {
+		percpu_stats[i] = 0; // atomic
+	}
+}
+
 /*
  * npf_stats: export collected statistics.
  */
+
 __dso_public void
 npf_stats(npf_t *npf, uint64_t *buf)
 {
 	memset(buf, 0, NPF_STATS_SIZE);
 	percpu_foreach(npf->stats_percpu, npf_stats_collect, buf);
+}
+
+__dso_public void
+npf_stats_clear(npf_t *npf)
+{
+	percpu_foreach(npf->stats_percpu, npf_stats_clear_cb, NULL);
 }

--- a/src/kern/npf_alg_icmp.c
+++ b/src/kern/npf_alg_icmp.c
@@ -453,8 +453,8 @@ err:
  * and module interface.
  */
 
-static int
-npf_alg_icmp_init(void)
+int
+npf_alg_icmp_init(npf_t *npf)
 {
 	static const npfa_funcs_t icmp = {
 		.match		= npfa_icmp_match,
@@ -465,21 +465,24 @@ npf_alg_icmp_init(void)
 	return alg_icmp ? 0 : ENOMEM;
 }
 
-static int
-npf_alg_icmp_fini(void)
+int
+npf_alg_icmp_fini(npf_t *npf)
 {
 	KASSERT(alg_icmp != NULL);
-	return npf_alg_unregister(npf_getkernctx(), alg_icmp);
+	return npf_alg_unregister(npf, alg_icmp);
 }
 
+#ifdef _KERNEL
 static int
 npf_alg_icmp_modcmd(modcmd_t cmd, void *arg)
 {
+	npf_t *npf = npf_getkernctx();
+
 	switch (cmd) {
 	case MODULE_CMD_INIT:
-		return npf_alg_icmp_init();
+		return npf_alg_icmp_init(npf);
 	case MODULE_CMD_FINI:
-		return npf_alg_icmp_fini();
+		return npf_alg_icmp_fini(npf);
 	case MODULE_CMD_AUTOUNLOAD:
 		return EBUSY;
 	default:
@@ -487,3 +490,4 @@ npf_alg_icmp_modcmd(modcmd_t cmd, void *arg)
 	}
 	return 0;
 }
+#endif

--- a/src/kern/npf_conn.c
+++ b/src/kern/npf_conn.c
@@ -43,8 +43,13 @@
  *
  *	All connections have two keys and thus two entries:
  *
- *		npf_conn_t::c_forw_entry for the forwards stream and
- *		npf_conn_t::c_back_entry for the backwards stream.
+ *	- npf_conn_getforwkey(con)        -- for the forwards stream;
+ *	- npf_conn_getbackkey(con, alen)  -- for the backwards stream.
+ *
+ *	Note: the keys are stored in npf_conn_t::c_keys[], which is used
+ *	to allocate variable-length npf_conn_t structures based on whether
+ *	the IPv4 or IPv6 addresses are used.  See the npf_connkey.c source
+ *	file for the description of the key layouts.
  *
  *	The keys are formed from the 5-tuple (source/destination address,
  *	source/destination port and the protocol).  Additional matching
@@ -111,9 +116,7 @@ __KERNEL_RCSID(0, "$NetBSD: npf_conn.c,v 1.26 2019/01/19 21:19:31 rmind Exp $");
 #include <netinet/tcp.h>
 
 #include <sys/atomic.h>
-#include <sys/condvar.h>
 #include <sys/kmem.h>
-#include <sys/kthread.h>
 #include <sys/mutex.h>
 #include <net/pfil.h>
 #include <sys/pool.h>
@@ -124,6 +127,9 @@ __KERNEL_RCSID(0, "$NetBSD: npf_conn.c,v 1.26 2019/01/19 21:19:31 rmind Exp $");
 #define __NPF_CONN_PRIVATE
 #include "npf_conn.h"
 #include "npf_impl.h"
+
+/* A helper to select the IPv4 or IPv6 connection cache. */
+#define	NPF_CONNCACHE(alen)	(((alen) >> 4) & 0x1)
 
 /*
  * Connection flags: PFIL_IN and PFIL_OUT values are reserved for direction.
@@ -136,7 +142,7 @@ CTASSERT(PFIL_ALL == (0x001 | 0x002));
 
 enum { CONN_TRACKING_OFF, CONN_TRACKING_ON };
 
-static nvlist_t *npf_conn_export(npf_t *, const npf_conn_t *);
+static nvlist_t *npf_conn_export(npf_t *, npf_conn_t *);
 
 /*
  * npf_conn_sys{init,fini}: initialise/destroy connection tracking.
@@ -145,8 +151,13 @@ static nvlist_t *npf_conn_export(npf_t *, const npf_conn_t *);
 void
 npf_conn_init(npf_t *npf, int flags)
 {
-	npf->conn_cache = pool_cache_init(sizeof(npf_conn_t), coherency_unit,
-	    0, 0, "npfconpl", NULL, IPL_NET, NULL, NULL, NULL);
+	npf->conn_cache[0] = pool_cache_init(
+	    offsetof(npf_conn_t, c_keys[NPF_CONNKEY_V4WORDS * 2]),
+	    0, 0, 0, "npfcn4pl", NULL, IPL_NET, NULL, NULL, NULL);
+	npf->conn_cache[1] = pool_cache_init(
+	    offsetof(npf_conn_t, c_keys[NPF_CONNKEY_V6WORDS * 2]),
+	    0, 0, 0, "npfcn6pl", NULL, IPL_NET, NULL, NULL, NULL);
+
 	mutex_init(&npf->conn_lock, MUTEX_DEFAULT, IPL_NONE);
 	npf->conn_tracking = CONN_TRACKING_OFF;
 	npf->conn_db = npf_conndb_create();
@@ -164,7 +175,8 @@ npf_conn_fini(npf_t *npf)
 	npf_worker_unregister(npf, npf_conn_worker);
 
 	npf_conndb_destroy(npf->conn_db);
-	pool_cache_destroy(npf->conn_cache);
+	pool_cache_destroy(npf->conn_cache[0]);
+	pool_cache_destroy(npf->conn_cache[1]);
 	mutex_destroy(&npf->conn_lock);
 }
 
@@ -206,7 +218,8 @@ npf_conn_load(npf_t *npf, npf_conndb_t *ndb, bool track)
 		 */
 		npf_conndb_gc(npf, odb, true, false);
 		npf_conndb_destroy(odb);
-		pool_cache_invalidate(npf->conn_cache);
+		pool_cache_invalidate(npf->conn_cache[0]);
+		pool_cache_invalidate(npf->conn_cache[1]);
 	}
 }
 
@@ -236,138 +249,6 @@ npf_conn_trackable_p(const npf_cache_t *npc)
 		return false;
 	}
 	return true;
-}
-
-static uint32_t
-connkey_setkey(npf_connkey_t *key, uint16_t proto, const void *ipv,
-    const uint16_t *id, unsigned alen, bool forw)
-{
-	uint32_t isrc, idst, *k = key->ck_key;
-	const npf_addr_t * const *ips = ipv;
-
-	if (__predict_true(forw)) {
-		isrc = NPF_SRC, idst = NPF_DST;
-	} else {
-		isrc = NPF_DST, idst = NPF_SRC;
-	}
-
-	/*
-	 * Construct a key formed out of 32-bit integers.  The key layout:
-	 *
-	 * Field: | proto  |  alen  | src-id | dst-id | src-addr | dst-addr |
-	 *        +--------+--------+--------+--------+----------+----------+
-	 * Bits:  |   16   |   16   |   16   |   16   |  32-128  |  32-128  |
-	 *
-	 * The source and destination are inverted if they key is for the
-	 * backwards stream (forw == false).  The address length depends
-	 * on the 'alen' field; it is a length in bytes, either 4 or 16.
-	 */
-
-	k[0] = ((uint32_t)proto << 16) | (alen & 0xffff);
-	k[1] = ((uint32_t)id[isrc] << 16) | id[idst];
-
-	if (__predict_true(alen == sizeof(in_addr_t))) {
-		k[2] = ips[isrc]->word32[0];
-		k[3] = ips[idst]->word32[0];
-		return 4 * sizeof(uint32_t);
-	} else {
-		const u_int nwords = alen >> 2;
-		memcpy(&k[2], ips[isrc], alen);
-		memcpy(&k[2 + nwords], ips[idst], alen);
-		return (2 + (nwords * 2)) * sizeof(uint32_t);
-	}
-}
-
-static void
-connkey_getkey(const npf_connkey_t *key, uint16_t *proto, npf_addr_t *ips,
-    uint16_t *id, uint16_t *alen)
-{
-	const uint32_t *k = key->ck_key;
-
-	*proto = k[0] >> 16;
-	*alen = k[0] & 0xffff;
-	id[NPF_SRC] = k[1] >> 16;
-	id[NPF_DST] = k[1] & 0xffff;
-
-	switch (*alen) {
-	case sizeof(struct in6_addr):
-	case sizeof(struct in_addr):
-		memcpy(&ips[NPF_SRC], &k[2], *alen);
-		memcpy(&ips[NPF_DST], &k[2 + ((unsigned)*alen >> 2)], *alen);
-		return;
-	default:
-		KASSERT(0);
-	}
-}
-
-/*
- * npf_conn_conkey: construct a key for the connection lookup.
- *
- * => Returns the key length in bytes or zero on failure.
- */
-unsigned
-npf_conn_conkey(const npf_cache_t *npc, npf_connkey_t *key, const bool forw)
-{
-	const u_int proto = npc->npc_proto;
-	const u_int alen = npc->npc_alen;
-	const struct tcphdr *th;
-	const struct udphdr *uh;
-	uint16_t id[2];
-
-	switch (proto) {
-	case IPPROTO_TCP:
-		KASSERT(npf_iscached(npc, NPC_TCP));
-		th = npc->npc_l4.tcp;
-		id[NPF_SRC] = th->th_sport;
-		id[NPF_DST] = th->th_dport;
-		break;
-	case IPPROTO_UDP:
-		KASSERT(npf_iscached(npc, NPC_UDP));
-		uh = npc->npc_l4.udp;
-		id[NPF_SRC] = uh->uh_sport;
-		id[NPF_DST] = uh->uh_dport;
-		break;
-	case IPPROTO_ICMP:
-		if (npf_iscached(npc, NPC_ICMP_ID)) {
-			const struct icmp *ic = npc->npc_l4.icmp;
-			id[NPF_SRC] = ic->icmp_id;
-			id[NPF_DST] = ic->icmp_id;
-			break;
-		}
-		return 0;
-	case IPPROTO_ICMPV6:
-		if (npf_iscached(npc, NPC_ICMP_ID)) {
-			const struct icmp6_hdr *ic6 = npc->npc_l4.icmp6;
-			id[NPF_SRC] = ic6->icmp6_id;
-			id[NPF_DST] = ic6->icmp6_id;
-			break;
-		}
-		return 0;
-	default:
-		/* Unsupported protocol. */
-		return 0;
-	}
-	return connkey_setkey(key, proto, npc->npc_ips, id, alen, forw);
-}
-
-static __inline void
-connkey_set_addr(npf_connkey_t *key, const npf_addr_t *naddr, const int di)
-{
-	const u_int alen = key->ck_key[0] & 0xffff;
-	uint32_t *addr = &key->ck_key[2 + ((alen >> 2) * di)];
-
-	KASSERT(alen > 0);
-	memcpy(addr, naddr, alen);
-}
-
-static __inline void
-connkey_set_id(npf_connkey_t *key, const uint16_t id, const int di)
-{
-	const uint32_t oid = key->ck_key[1];
-	const u_int shift = 16 * !di;
-	const uint32_t mask = 0xffff0000 >> shift;
-
-	key->ck_key[1] = ((uint32_t)id << shift) | (oid & mask);
 }
 
 static inline void
@@ -513,7 +394,10 @@ npf_conn_t *
 npf_conn_establish(npf_cache_t *npc, int di, bool per_if)
 {
 	npf_t *npf = npc->npc_ctx;
+	const unsigned alen = npc->npc_alen;
+	const unsigned idx = NPF_CONNCACHE(alen);
 	const nbuf_t *nbuf = npc->npc_nbuf;
+	npf_connkey_t *fw, *bk;
 	npf_conn_t *con;
 	int error = 0;
 
@@ -524,7 +408,7 @@ npf_conn_establish(npf_cache_t *npc, int di, bool per_if)
 	}
 
 	/* Allocate and initialise the new connection. */
-	con = pool_cache_get(npf->conn_cache, PR_NOWAIT);
+	con = pool_cache_get(npf->conn_cache[idx], PR_NOWAIT);
 	if (__predict_false(!con)) {
 		npf_worker_signal(npf);
 		return NULL;
@@ -538,15 +422,18 @@ npf_conn_establish(npf_cache_t *npc, int di, bool per_if)
 	con->c_rproc = NULL;
 	con->c_nat = NULL;
 
+	con->c_proto = npc->npc_proto;
+	CTASSERT(sizeof(con->c_proto) >= sizeof(npc->npc_proto));
+
 	/* Initialize the protocol state. */
 	if (!npf_state_init(npc, &con->c_state)) {
 		npf_conn_destroy(npf, con);
 		return NULL;
 	}
-
 	KASSERT(npf_iscached(npc, NPC_IP46));
-	npf_connkey_t *fw = &con->c_forw_entry;
-	npf_connkey_t *bk = &con->c_back_entry;
+
+	fw = npf_conn_getforwkey(con);
+	bk = npf_conn_getbackkey(con, alen);
 
 	/*
 	 * Construct "forwards" and "backwards" keys.  Also, set the
@@ -557,9 +444,7 @@ npf_conn_establish(npf_cache_t *npc, int di, bool per_if)
 		npf_conn_destroy(npf, con);
 		return NULL;
 	}
-	fw->ck_backptr = bk->ck_backptr = con;
 	con->c_ifid = per_if ? nbuf->nb_ifid : 0;
-	con->c_proto = npc->npc_proto;
 
 	/*
 	 * Set last activity time for a new connection and acquire
@@ -574,11 +459,11 @@ npf_conn_establish(npf_cache_t *npc, int di, bool per_if)
 	 * the connection later.
 	 */
 	mutex_enter(&con->c_lock);
-	if (!npf_conndb_insert(npf->conn_db, fw)) {
+	if (!npf_conndb_insert(npf->conn_db, fw, con, true)) {
 		error = EISCONN;
 		goto err;
 	}
-	if (!npf_conndb_insert(npf->conn_db, bk)) {
+	if (!npf_conndb_insert(npf->conn_db, bk, con, false)) {
 		npf_conn_t *ret __diagused;
 		ret = npf_conndb_remove(npf->conn_db, fw);
 		KASSERT(ret == con);
@@ -609,6 +494,10 @@ err:
 void
 npf_conn_destroy(npf_t *npf, npf_conn_t *con)
 {
+	const npf_connkey_t *key = npf_conn_getforwkey(con);
+	const unsigned alen = NPF_CONNKEY_ALEN(key);
+	const unsigned idx __unused = NPF_CONNCACHE(alen);
+
 	KASSERT(con->c_refcnt == 0);
 
 	if (con->c_nat) {
@@ -625,7 +514,7 @@ npf_conn_destroy(npf_t *npf, npf_conn_t *con)
 	mutex_destroy(&con->c_lock);
 
 	/* Free the structure, increase the counter. */
-	pool_cache_put(npf->conn_cache, con);
+	pool_cache_put(npf->conn_cache[idx], con);
 	npf_stats_inc(npf, NPF_STAT_CONN_DESTROY);
 	NPF_PRINTF(("NPF: conn %p destroyed\n", con));
 }
@@ -638,24 +527,22 @@ npf_conn_destroy(npf_t *npf, npf_conn_t *con)
  */
 int
 npf_conn_setnat(const npf_cache_t *npc, npf_conn_t *con,
-    npf_nat_t *nt, u_int ntype)
+    npf_nat_t *nt, unsigned ntype)
 {
 	static const u_int nat_type_dimap[] = {
 		[NPF_NATOUT] = NPF_DST,
 		[NPF_NATIN] = NPF_SRC,
 	};
 	npf_t *npf = npc->npc_ctx;
-	npf_connkey_t key, *bk;
+	npf_connkey_t key, *fw, *bk;
 	npf_conn_t *ret __diagused;
 	npf_addr_t *taddr;
 	in_port_t tport;
-	u_int tidx;
 
 	KASSERT(con->c_refcnt > 0);
 
 	npf_nat_gettrans(nt, &taddr, &tport);
 	KASSERT(ntype == NPF_NATOUT || ntype == NPF_NATIN);
-	tidx = nat_type_dimap[ntype];
 
 	/* Construct a "backwards" key. */
 	if (!npf_conn_conkey(npc, &key, false)) {
@@ -678,24 +565,22 @@ npf_conn_setnat(const npf_cache_t *npc, npf_conn_t *con,
 		return EISCONN;
 	}
 
-	/* Remove the "backwards" entry. */
-	ret = npf_conndb_remove(npf->conn_db, &con->c_back_entry);
+	/* Remove the "backwards" key. */
+	fw = npf_conn_getforwkey(con);
+	bk = npf_conn_getbackkey(con, NPF_CONNKEY_ALEN(fw));
+	ret = npf_conndb_remove(npf->conn_db, bk);
 	KASSERT(ret == con);
 
 	/* Set the source/destination IDs to the translation values. */
-	bk = &con->c_back_entry;
-	connkey_set_addr(bk, taddr, tidx);
-	if (tport) {
-		connkey_set_id(bk, tport, tidx);
-	}
+	npf_conn_adjkey(bk, taddr, tport, nat_type_dimap[ntype]);
 
-	/* Finally, re-insert the "backwards" entry. */
-	if (!npf_conndb_insert(npf->conn_db, bk)) {
+	/* Finally, re-insert the "backwards" key. */
+	if (!npf_conndb_insert(npf->conn_db, bk, con, false)) {
 		/*
 		 * Race: we have hit the duplicate, remove the "forwards"
-		 * entry and expire our connection; it is no longer valid.
+		 * key and expire our connection; it is no longer valid.
 		 */
-		ret = npf_conndb_remove(npf->conn_db, &con->c_forw_entry);
+		ret = npf_conndb_remove(npf->conn_db, fw);
 		KASSERT(ret == con);
 
 		atomic_or_uint(&con->c_flags, CONN_REMOVED | CONN_EXPIRE);
@@ -819,11 +704,15 @@ npf_conn_remove(npf_conndb_t *cd, npf_conn_t *con)
 	/* Remove both entries of the connection. */
 	mutex_enter(&con->c_lock);
 	if ((con->c_flags & CONN_REMOVED) == 0) {
+		npf_connkey_t *fw, *bk;
 		npf_conn_t *ret __diagused;
 
-		ret = npf_conndb_remove(cd, &con->c_forw_entry);
+		fw = npf_conn_getforwkey(con);
+		ret = npf_conndb_remove(cd, fw);
 		KASSERT(ret == con);
-		ret = npf_conndb_remove(cd, &con->c_back_entry);
+
+		bk = npf_conn_getbackkey(con, NPF_CONNKEY_ALEN(fw));
+		ret = npf_conndb_remove(cd, bk);
 		KASSERT(ret == con);
 	}
 
@@ -876,30 +765,15 @@ npf_conndb_export(npf_t *npf, nvlist_t *npf_dict)
 	return 0;
 }
 
-static nvlist_t *
-npf_connkey_export(const npf_connkey_t *key)
-{
-	uint16_t id[2], alen, proto;
-	npf_addr_t ips[2];
-	nvlist_t *kdict;
-
-	kdict = nvlist_create(0);
-	connkey_getkey(key, &proto, ips, id, &alen);
-	nvlist_add_number(kdict, "proto", proto);
-	nvlist_add_number(kdict, "sport", id[NPF_SRC]);
-	nvlist_add_number(kdict, "dport", id[NPF_DST]);
-	nvlist_add_binary(kdict, "saddr", &ips[NPF_SRC], alen);
-	nvlist_add_binary(kdict, "daddr", &ips[NPF_DST], alen);
-	return kdict;
-}
-
 /*
  * npf_conn_export: serialise a single connection.
  */
 static nvlist_t *
-npf_conn_export(npf_t *npf, const npf_conn_t *con)
+npf_conn_export(npf_t *npf, npf_conn_t *con)
 {
 	nvlist_t *cdict, *kdict;
+	npf_connkey_t *fw, *bk;
+	unsigned alen;
 
 	if ((con->c_flags & (CONN_ACTIVE|CONN_EXPIRE)) != CONN_ACTIVE) {
 		return NULL;
@@ -913,34 +787,23 @@ npf_conn_export(npf_t *npf, const npf_conn_t *con)
 	}
 	nvlist_add_binary(cdict, "state", &con->c_state, sizeof(npf_state_t));
 
-	kdict = npf_connkey_export(&con->c_forw_entry);
+	fw = npf_conn_getforwkey(con);
+	alen = NPF_CONNKEY_ALEN(fw);
+	bk = npf_conn_getbackkey(con, alen);
+
+	kdict = npf_connkey_export(fw);
 	nvlist_move_nvlist(cdict, "forw-key", kdict);
 
-	kdict = npf_connkey_export(&con->c_back_entry);
+	kdict = npf_connkey_export(bk);
 	nvlist_move_nvlist(cdict, "back-key", kdict);
+
+	/* Let the address length be based on on first key. */
+	nvlist_add_number(cdict, "alen", alen);
 
 	if (con->c_nat) {
 		npf_nat_export(cdict, con->c_nat);
 	}
 	return cdict;
-}
-
-static uint32_t
-npf_connkey_import(const nvlist_t *kdict, npf_connkey_t *key)
-{
-	npf_addr_t const * ips[2];
-	uint16_t proto, id[2];
-	size_t alen1, alen2;
-
-	proto = dnvlist_get_number(kdict, "proto", 0);
-	id[NPF_SRC] = dnvlist_get_number(kdict, "sport", 0);
-	id[NPF_DST] = dnvlist_get_number(kdict, "dport", 0);
-	ips[NPF_SRC] = dnvlist_get_binary(kdict, "saddr", &alen1, NULL, 0);
-	ips[NPF_DST] = dnvlist_get_binary(kdict, "daddr", &alen2, NULL, 0);
-	if (__predict_false(alen1 == 0 || alen1 != alen2)) {
-		return 0;
-	}
-	return connkey_setkey(key, proto, ips, id, alen1, true);
 }
 
 /*
@@ -956,10 +819,18 @@ npf_conn_import(npf_t *npf, npf_conndb_t *cd, const nvlist_t *cdict,
 	const nvlist_t *nat, *conkey;
 	const char *ifname;
 	const void *state;
+	unsigned alen, idx;
 	size_t len;
 
+	/*
+	 * To determine the length of the connection, which depends
+	 * on the address length in the connection keys.
+	 */
+	alen = dnvlist_get_number(cdict, "alen", 0);
+	idx = NPF_CONNCACHE(alen);
+
 	/* Allocate a connection and initialise it (clear first). */
-	con = pool_cache_get(npf->conn_cache, PR_WAITOK);
+	con = pool_cache_get(npf->conn_cache[idx], PR_WAITOK);
 	memset(con, 0, sizeof(npf_conn_t));
 	mutex_init(&con->c_lock, MUTEX_DEFAULT, IPL_SOFTNET);
 	npf_stats_inc(npf, NPF_STAT_CONN_CREATE);
@@ -989,23 +860,27 @@ npf_conn_import(npf_t *npf, npf_conndb_t *cd, const nvlist_t *cdict,
 	/*
 	 * Fetch and copy the keys for each direction.
 	 */
+	fw = npf_conn_getforwkey(con);
 	conkey = dnvlist_get_nvlist(cdict, "forw-key", NULL);
-	fw = &con->c_forw_entry;
-	if (conkey == NULL || !npf_connkey_import(conkey, fw)) {
+	if (conkey == NULL || !npf_connkey_import(conkey, fw, true)) {
 		goto err;
 	}
+	bk = npf_conn_getbackkey(con, NPF_CONNKEY_ALEN(fw));
 	conkey = dnvlist_get_nvlist(cdict, "back-key", NULL);
-	bk = &con->c_back_entry;
-	if (conkey == NULL || !npf_connkey_import(conkey, bk)) {
+	if (conkey == NULL || !npf_connkey_import(conkey, bk, false)) {
 		goto err;
 	}
-	fw->ck_backptr = bk->ck_backptr = con;
+
+	/* Guard against the contradicting address lengths. */
+	if (NPF_CONNKEY_ALEN(fw) != alen || NPF_CONNKEY_ALEN(bk) != alen) {
+		goto err;
+	}
 
 	/* Insert the entries and the connection itself. */
-	if (!npf_conndb_insert(cd, fw)) {
+	if (!npf_conndb_insert(cd, fw, con, true)) {
 		goto err;
 	}
-	if (!npf_conndb_insert(cd, bk)) {
+	if (!npf_conndb_insert(cd, bk, con, false)) {
 		npf_conndb_remove(cd, fw);
 		goto err;
 	}
@@ -1028,10 +903,10 @@ npf_conn_find(npf_t *npf, const nvlist_t *idict, nvlist_t **odict)
 	bool forw;
 
 	kdict = dnvlist_get_nvlist(idict, "key", NULL);
-	if (!kdict || !npf_connkey_import(kdict, &key)) {
+	dir = dnvlist_get_number(idict, "direction", 0);
+	if (!kdict || !npf_connkey_import(kdict, &key, dir)) {
 		return EINVAL;
 	}
-	dir = dnvlist_get_number(idict, "direction", 0);
 	con = npf_conndb_lookup(npf->conn_db, &key, &forw);
 	if (con == NULL) {
 		return ESRCH;
@@ -1048,12 +923,14 @@ npf_conn_find(npf_t *npf, const nvlist_t *idict, nvlist_t **odict)
 #if defined(DDB) || defined(_NPF_TESTING)
 
 void
-npf_conn_print(const npf_conn_t *con)
+npf_conn_print(npf_conn_t *con)
 {
-	const u_int alen = NPF_CONN_GETALEN(&con->c_forw_entry);
-	const uint32_t *fkey = con->c_forw_entry.ck_key;
-	const uint32_t *bkey = con->c_back_entry.ck_key;
-	const u_int proto = con->c_proto;
+	const npf_connkey_t *fw = npf_conn_getforwkey(con);
+	const unsigned alen = NPF_CONNKEY_ALEN(fw);
+	const npf_connkey_t *bk = npf_conn_getbackkey(con, alen);
+	const uint32_t *fkey = fw->ck_key;
+	const uint32_t *bkey = bk->ck_key;
+	const unsigned proto = con->c_proto;
 	struct timespec tspnow;
 	const void *src, *dst;
 	int etime;

--- a/src/kern/npf_conn.c
+++ b/src/kern/npf_conn.c
@@ -862,12 +862,12 @@ npf_conn_import(npf_t *npf, npf_conndb_t *cd, const nvlist_t *cdict,
 	 */
 	fw = npf_conn_getforwkey(con);
 	conkey = dnvlist_get_nvlist(cdict, "forw-key", NULL);
-	if (conkey == NULL || !npf_connkey_import(conkey, fw, true)) {
+	if (conkey == NULL || !npf_connkey_import(conkey, fw)) {
 		goto err;
 	}
 	bk = npf_conn_getbackkey(con, NPF_CONNKEY_ALEN(fw));
 	conkey = dnvlist_get_nvlist(cdict, "back-key", NULL);
-	if (conkey == NULL || !npf_connkey_import(conkey, bk, false)) {
+	if (conkey == NULL || !npf_connkey_import(conkey, bk)) {
 		goto err;
 	}
 
@@ -904,7 +904,7 @@ npf_conn_find(npf_t *npf, const nvlist_t *idict, nvlist_t **odict)
 
 	kdict = dnvlist_get_nvlist(idict, "key", NULL);
 	dir = dnvlist_get_number(idict, "direction", 0);
-	if (!kdict || !npf_connkey_import(kdict, &key, dir)) {
+	if (!kdict || !npf_connkey_import(kdict, &key)) {
 		return EINVAL;
 	}
 	con = npf_conndb_lookup(npf->conn_db, &key, &forw);

--- a/src/kern/npf_conn.h
+++ b/src/kern/npf_conn.h
@@ -101,9 +101,10 @@ struct npf_conn {
 #define	NPF_CONNKEY_MAXWORDS	(NPF_CONNKEY_V6WORDS)
 
 #define	NPF_CONNKEY_ALEN(key)	((key)->ck_key[0] & 0xffff)
-#define	NPF_CONNKEY_LEN(key)	(8 + (2 * NPF_CONNKEY_ALEN(key)))
+#define	NPF_CONNKEY_LEN(key)	(8 + (NPF_CONNKEY_ALEN(key) * 2))
 
 struct npf_connkey {
+	/* Warning: ck_key has a variable length -- see above. */
 	uint32_t		ck_key[NPF_CONNKEY_MAXWORDS];
 };
 
@@ -113,7 +114,7 @@ npf_connkey_t *	npf_conn_getbackkey(npf_conn_t *, unsigned);
 void		npf_conn_adjkey(npf_connkey_t *, const npf_addr_t *,
 		    const uint16_t, const int);
 
-unsigned	npf_connkey_import(const nvlist_t *, npf_connkey_t *, bool);
+unsigned	npf_connkey_import(const nvlist_t *, npf_connkey_t *);
 nvlist_t *	npf_connkey_export(const npf_connkey_t *);
 
 #endif

--- a/src/kern/npf_conn.h
+++ b/src/kern/npf_conn.h
@@ -116,6 +116,7 @@ void		npf_conn_adjkey(npf_connkey_t *, const npf_addr_t *,
 
 unsigned	npf_connkey_import(const nvlist_t *, npf_connkey_t *);
 nvlist_t *	npf_connkey_export(const npf_connkey_t *);
+void		npf_connkey_print(const npf_connkey_t *);
 
 #endif
 

--- a/src/kern/npf_conn.h
+++ b/src/kern/npf_conn.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2009-2014 The NetBSD Foundation, Inc.
+ * Copyright (c) 2009-2019 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * This material is based upon work partially supported by The
@@ -43,34 +43,20 @@ typedef struct npf_connkey npf_connkey_t;
 #if defined(__NPF_CONN_PRIVATE)
 
 /*
- * See npf_conn_conkey() function for the key layout description.
- */
-#define	NPF_CONN_NKEYWORDS	(2 + ((sizeof(npf_addr_t) * 2) >> 2))
-#define	NPF_CONN_GETALEN(key)	((key)->ck_key[0] & 0xffff)
-#define	NPF_CONN_KEYLEN(key)	(8 + (2 * NPF_CONN_GETALEN(key)))
-
-struct npf_connkey {
-	/*
-	 * Back-pointer to the actual connection and the compacted key.
-	 */
-	npf_conn_t *	ck_backptr;
-	uint32_t	ck_key[NPF_CONN_NKEYWORDS];
-};
-
-/*
  * The main connection tracking structure.
  */
-
 struct npf_conn {
 	/*
-	 * Connection "forwards" and "backwards" entries, plus the
-	 * interface ID (if zero, then the state is global) and flags.
+	 * Protocol, address length, the interface ID (if zero,
+	 * then the state is global) and connection flags.
 	 */
-	npf_connkey_t		c_forw_entry;
-	npf_connkey_t		c_back_entry;
-	u_int			c_proto;
-	u_int			c_ifid;
-	u_int			c_flags;
+	unsigned		c_proto;
+	unsigned		c_ifid;
+	unsigned		c_flags;
+
+	/* Matching rule flags and ID. */
+	unsigned		c_retfl;
+	uint64_t		c_rid;
 
 	/*
 	 * Entry in the connection database/list.  The entry is
@@ -86,20 +72,49 @@ struct npf_conn {
 	npf_nat_t *		c_nat;
 
 	/*
-	 * The protocol state, reference count and the last activity
-	 * time (used to calculate expiration time).
+	 * The Reference count and the last activity time (used to
+	 * calculate expiration time).  Note: *unsigned* 32-bit integer
+	 * as a timestamp is sufficient for us.
 	 */
+	unsigned		c_refcnt;
+	uint32_t		c_atime;
+
+	/* The protocol state and lock. */
 	kmutex_t		c_lock;
 	npf_state_t		c_state;
-	u_int			c_refcnt;
-	uint64_t		c_atime;
 
 	/*
-	 * Save the matching rule ID and flags.
+	 * Connection "forwards" and "backwards" keys.  They are accessed
+	 * as npf_connkey_t, see below and npf_conn_getkey().
 	 */
-	uint64_t		c_rid;
-	u_int			c_retfl;
+	uint32_t		c_keys[];
 };
+
+/*
+ * Connection key interface.
+ *
+ * See the key layout description in the npf_connkey.c source file.
+ */
+
+#define	NPF_CONNKEY_V4WORDS	(2 + ((sizeof(struct in_addr) * 2) >> 2))
+#define	NPF_CONNKEY_V6WORDS	(2 + ((sizeof(struct in6_addr) * 2) >> 2))
+#define	NPF_CONNKEY_MAXWORDS	(NPF_CONNKEY_V6WORDS)
+
+#define	NPF_CONNKEY_ALEN(key)	((key)->ck_key[0] & 0xffff)
+#define	NPF_CONNKEY_LEN(key)	(8 + (2 * NPF_CONNKEY_ALEN(key)))
+
+struct npf_connkey {
+	uint32_t		ck_key[NPF_CONNKEY_MAXWORDS];
+};
+
+unsigned	npf_conn_conkey(const npf_cache_t *, npf_connkey_t *, bool);
+npf_connkey_t *	npf_conn_getforwkey(npf_conn_t *);
+npf_connkey_t *	npf_conn_getbackkey(npf_conn_t *, unsigned);
+void		npf_conn_adjkey(npf_connkey_t *, const npf_addr_t *,
+		    const uint16_t, const int);
+
+unsigned	npf_connkey_import(const nvlist_t *, npf_connkey_t *, bool);
+nvlist_t *	npf_connkey_export(const npf_connkey_t *);
 
 #endif
 
@@ -111,7 +126,6 @@ void		npf_conn_fini(npf_t *);
 void		npf_conn_tracking(npf_t *, bool);
 void		npf_conn_load(npf_t *, npf_conndb_t *, bool);
 
-unsigned	npf_conn_conkey(const npf_cache_t *, npf_connkey_t *, bool);
 npf_conn_t *	npf_conn_lookup(const npf_cache_t *, const int, bool *);
 npf_conn_t *	npf_conn_inspect(npf_cache_t *, const int, int *);
 npf_conn_t *	npf_conn_establish(npf_cache_t *, int, bool);
@@ -131,7 +145,7 @@ void		npf_conn_worker(npf_t *);
 int		npf_conn_import(npf_t *, npf_conndb_t *, const nvlist_t *,
 		    npf_ruleset_t *);
 int		npf_conn_find(npf_t *, const nvlist_t *, nvlist_t **);
-void		npf_conn_print(const npf_conn_t *);
+void		npf_conn_print(npf_conn_t *);
 
 /*
  * Connection database (aka state table) interface.
@@ -140,7 +154,8 @@ npf_conndb_t *	npf_conndb_create(void);
 void		npf_conndb_destroy(npf_conndb_t *);
 
 npf_conn_t *	npf_conndb_lookup(npf_conndb_t *, const npf_connkey_t *, bool *);
-bool		npf_conndb_insert(npf_conndb_t *, npf_connkey_t *);
+bool		npf_conndb_insert(npf_conndb_t *, const npf_connkey_t *,
+		    npf_conn_t *, bool);
 npf_conn_t *	npf_conndb_remove(npf_conndb_t *, npf_connkey_t *);
 
 void		npf_conndb_enqueue(npf_conndb_t *, npf_conn_t *);

--- a/src/kern/npf_connkey.c
+++ b/src/kern/npf_connkey.c
@@ -1,0 +1,259 @@
+/*-
+ * Copyright (c) 2014-2019 Mindaugas Rasiukevicius <rmind at netbsd org>
+ * Copyright (c) 2010-2014 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This material is based upon work partially supported by The
+ * NetBSD Foundation under a contract with Mindaugas Rasiukevicius.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Connection key -- is a structure encoding the 5-tuple (protocol, address
+ * length, source/destination address and source/destination port/ID).
+ *
+ * Key layout
+ *
+ *	The single key is formed out of 32-bit integers.  The layout is:
+ *
+ *	Field: | proto  |  alen  | src-id | dst-id | src-addr | dst-addr |
+ *	       +--------+--------+--------+--------+----------+----------+
+ *	Bits:  |   16   |   16   |   16   |   16   |  32-128  |  32-128  |
+ *
+ *	The source and destination are inverted if the key is for the
+ *	backwards stream (forw == false).  The address length depends on
+ *	the 'alen' field.  The length is in bytes and is either 4 or 16.
+ *
+ *	Warning: the keys must be immutable while they are in conndb.
+ *
+ * Embedding in the connection structure (npf_conn_t)
+ *
+ *	Two keys are stored in the npf_conn_t::c_keys[] array, which is
+ *	variable-length, depending on whether the keys store IPv4 or IPv6
+ *	addresses.  The length of the first key determines the position
+ *	of the second key.
+ */
+
+#ifdef _KERNEL
+#include <sys/cdefs.h>
+__KERNEL_RCSID(0, "$NetBSD$");
+
+#include <sys/param.h>
+#include <sys/types.h>
+#endif
+
+#define __NPF_CONN_PRIVATE
+#include "npf_conn.h"
+#include "npf_impl.h"
+
+static inline unsigned
+connkey_setkey(npf_connkey_t *key, uint16_t proto, const void *ipv,
+    const uint16_t *id, unsigned alen, bool forw)
+{
+	const npf_addr_t * const *ips = ipv;
+	uint32_t * const k = key->ck_key;
+
+	/*
+	 * See the key layout explanation above.
+	 */
+
+	k[0] = ((uint32_t)proto << 16) | (alen & 0xffff);
+	k[1] = ((uint32_t)id[NPF_SRC] << 16) | id[NPF_DST];
+
+	if (__predict_true(alen == sizeof(in_addr_t))) {
+		k[2] = ips[NPF_SRC]->word32[0];
+		k[3] = ips[NPF_DST]->word32[0];
+		return 4 * sizeof(uint32_t);
+	} else {
+		const unsigned nwords = alen >> 2;
+		memcpy(&k[2], ips[NPF_SRC], alen);
+		memcpy(&k[2 + nwords], ips[NPF_DST], alen);
+		return (2 + (nwords * 2)) * sizeof(uint32_t);
+	}
+}
+
+static inline void
+connkey_getkey(const npf_connkey_t *key, uint16_t *proto, npf_addr_t *ips,
+    uint16_t *id, uint16_t *alen)
+{
+	const uint32_t *k = key->ck_key;
+
+	/*
+	 * See the key layout explanation above.
+	 */
+
+	*proto = k[0] >> 16;
+	*alen = k[0] & 0xffff;
+	id[NPF_SRC] = k[1] >> 16;
+	id[NPF_DST] = k[1] & 0xffff;
+
+	switch (*alen) {
+	case sizeof(struct in6_addr):
+	case sizeof(struct in_addr):
+		memcpy(&ips[NPF_SRC], &k[2], *alen);
+		memcpy(&ips[NPF_DST], &k[2 + ((unsigned)*alen >> 2)], *alen);
+		return;
+	default:
+		KASSERT(0);
+	}
+}
+
+/*
+ * npf_conn_adjkey: adjust the connection key by resetting the address/port.
+ */
+void
+npf_conn_adjkey(npf_connkey_t *key, const npf_addr_t *naddr,
+    const uint16_t id, const int di)
+{
+	uint32_t * const k = key->ck_key;
+	const unsigned alen = k[0] & 0xffff;
+	uint32_t *addr = &k[2 + ((alen >> 2) * di)];
+
+	KASSERT(alen > 0);
+	memcpy(addr, naddr, alen);
+
+	if (id) {
+		const uint32_t oid = k[1];
+		const unsigned shift = 16 * !di;
+		const uint32_t mask = 0xffff0000 >> shift;
+		k[1] = ((uint32_t)id << shift) | (oid & mask);
+	}
+}
+
+/*
+ * npf_conn_conkey: construct a key for the connection lookup.
+ *
+ * => Returns the key length in bytes or zero on failure.
+ */
+unsigned
+npf_conn_conkey(const npf_cache_t *npc, npf_connkey_t *key, const bool forw)
+{
+	const unsigned proto = npc->npc_proto;
+	const unsigned alen = npc->npc_alen;
+	const struct tcphdr *th;
+	const struct udphdr *uh;
+	unsigned isrc, idst;
+	uint16_t id[2];
+
+	if (__predict_true(forw)) {
+		isrc = NPF_SRC, idst = NPF_DST;
+	} else {
+		isrc = NPF_DST, idst = NPF_SRC;
+	}
+
+	switch (proto) {
+	case IPPROTO_TCP:
+		KASSERT(npf_iscached(npc, NPC_TCP));
+		th = npc->npc_l4.tcp;
+		id[isrc] = th->th_sport;
+		id[idst] = th->th_dport;
+		break;
+	case IPPROTO_UDP:
+		KASSERT(npf_iscached(npc, NPC_UDP));
+		uh = npc->npc_l4.udp;
+		id[isrc] = uh->uh_sport;
+		id[idst] = uh->uh_dport;
+		break;
+	case IPPROTO_ICMP:
+		if (npf_iscached(npc, NPC_ICMP_ID)) {
+			const struct icmp *ic = npc->npc_l4.icmp;
+			id[isrc] = ic->icmp_id;
+			id[idst] = ic->icmp_id;
+			break;
+		}
+		return 0;
+	case IPPROTO_ICMPV6:
+		if (npf_iscached(npc, NPC_ICMP_ID)) {
+			const struct icmp6_hdr *ic6 = npc->npc_l4.icmp6;
+			id[isrc] = ic6->icmp6_id;
+			id[idst] = ic6->icmp6_id;
+			break;
+		}
+		return 0;
+	default:
+		/* Unsupported protocol. */
+		return 0;
+	}
+	return connkey_setkey(key, proto, npc->npc_ips, id, alen, forw);
+}
+
+/*
+ * npf_conn_getforwkey: get the address to the "forwards" key.
+ */
+npf_connkey_t *
+npf_conn_getforwkey(npf_conn_t *conn)
+{
+	return (void *)&conn->c_keys[0];
+}
+
+/*
+ * npf_conn_getbackkey: get the address to the "backwards" key.
+ *
+ * => It depends on the address length.
+ */
+npf_connkey_t *
+npf_conn_getbackkey(npf_conn_t *conn, unsigned alen)
+{
+	const unsigned off = 2 + ((alen * 2) >> 2);
+	KASSERT(off == NPF_CONNKEY_V4WORDS || off == NPF_CONNKEY_V6WORDS);
+	return (void *)&conn->c_keys[off];
+}
+
+/*
+ * Connection key exporting/importing.
+ */
+
+nvlist_t *
+npf_connkey_export(const npf_connkey_t *key)
+{
+	uint16_t id[2], alen, proto;
+	npf_addr_t ips[2];
+	nvlist_t *kdict;
+
+	kdict = nvlist_create(0);
+	connkey_getkey(key, &proto, ips, id, &alen);
+	nvlist_add_number(kdict, "proto", proto);
+	nvlist_add_number(kdict, "sport", id[NPF_SRC]);
+	nvlist_add_number(kdict, "dport", id[NPF_DST]);
+	nvlist_add_binary(kdict, "saddr", &ips[NPF_SRC], alen);
+	nvlist_add_binary(kdict, "daddr", &ips[NPF_DST], alen);
+	return kdict;
+}
+
+unsigned
+npf_connkey_import(const nvlist_t *kdict, npf_connkey_t *key, bool forw)
+{
+	npf_addr_t const * ips[2];
+	uint16_t proto, id[2];
+	size_t alen1, alen2;
+
+	proto = dnvlist_get_number(kdict, "proto", 0);
+	id[NPF_SRC] = dnvlist_get_number(kdict, "sport", 0);
+	id[NPF_DST] = dnvlist_get_number(kdict, "dport", 0);
+	ips[NPF_SRC] = dnvlist_get_binary(kdict, "saddr", &alen1, NULL, 0);
+	ips[NPF_DST] = dnvlist_get_binary(kdict, "daddr", &alen2, NULL, 0);
+	if (alen1 == 0 || alen1 > sizeof(npf_addr_t) || alen1 != alen2) {
+		return 0;
+	}
+	return connkey_setkey(key, proto, ips, id, alen1, forw);
+}

--- a/src/kern/npf_impl.h
+++ b/src/kern/npf_impl.h
@@ -179,11 +179,12 @@ struct npf {
 	/*
 	 * Connection tracking state: disabled (off) or enabled (on).
 	 * Connection tracking database, connection cache and the lock.
+	 * There are two caches (pools): for IPv4 and IPv6.
 	 */
 	volatile int		conn_tracking;
 	kmutex_t		conn_lock;
 	npf_conndb_t *		conn_db;
-	pool_cache_t		conn_cache;
+	pool_cache_t		conn_cache[2];
 
 	/* ALGs. */
 	npf_algset_t *		algset;

--- a/src/kern/npf_tableset.c
+++ b/src/kern/npf_tableset.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2009-2018 The NetBSD Foundation, Inc.
+ * Copyright (c) 2009-2019 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * This material is based upon work partially supported by The
@@ -35,6 +35,13 @@
  *	The tableset is an array of tables.  After the creation, the array
  *	is immutable.  The caller is responsible to synchronise the access
  *	to the tableset.
+ *
+ * Warning (not applicable for the userspace npfkern):
+ *
+ *	The thmap_put()/thmap_del() are not called from the interrupt
+ *	context and are protected by a mutex(9), therefore they do not
+ *	SPL wrappers -- see the comment at the top of the npf_conndb.c
+ *	source file.
  */
 
 #ifdef _KERNEL

--- a/src/kern/npfkern.h
+++ b/src/kern/npfkern.h
@@ -75,5 +75,13 @@ int	npf_packet_handler(npf_t *, struct mbuf **, struct ifnet *, int);
 void	npf_ifmap_attach(npf_t *, struct ifnet *);
 void	npf_ifmap_detach(npf_t *, struct ifnet *);
 void	npf_stats(npf_t *, uint64_t *);
+void	npf_stats_clear(npf_t *);
+
+/*
+ * ALGs
+ */
+
+int	npf_alg_icmp_init(npf_t *);
+int	npf_alg_icmp_fini(npf_t *);
 
 #endif

--- a/src/kern/npfkern.h
+++ b/src/kern/npfkern.h
@@ -78,7 +78,7 @@ void	npf_stats(npf_t *, uint64_t *);
 void	npf_stats_clear(npf_t *);
 
 /*
- * ALGs
+ * ALGs.
  */
 
 int	npf_alg_icmp_init(npf_t *);

--- a/src/kern/stand/npf_stand.h
+++ b/src/kern/stand/npf_stand.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2015 The NetBSD Foundation, Inc.
+ * Copyright (c) 2015-2019 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -212,6 +212,13 @@ npfkern_pthread_create(lwp_t **lret, void (*func)(void *), void *arg)
     npfkern_pthread_create(thr, func, arg)
 #define	kthread_join(t)	{ void *__r; pthread_join((t)->thr, &__r); free(t); }
 #define	kthread_exit(x)	pthread_exit(NULL);
+
+/*
+ * SPL wrappers.
+ */
+
+#define	splsoftnet()		0
+#define	splx(l)			(void)s;
 
 /*
  * Memory allocators and management.

--- a/src/npfctl/npf.conf.5
+++ b/src/npfctl/npf.conf.5
@@ -148,12 +148,16 @@ The
 .Cm family
 keyword of a filtering rule can be used in combination to explicitly select
 an IP address type.
+This function can also be used with
+.Cm map
+to specify the translation address, see below.
 .El
 .Pp
 Example of configuration:
 .Bd -literal -offset indent
 $var1 = inet4(wm0)
 $var2 = ifaddrs(wm0)
+
 group default {
 	block in on wm0 all               # rule 1
 	block in on $var1 all             # rule 2
@@ -349,6 +353,11 @@ For example, the following provides
 redirecting the public port 9022 to the port 22 of an internal host:
 .Pp
 .Dl map $ext_if dynamic proto tcp 10.1.1.2 port 22 <- $ext_if port 9022
+.Pp
+The translation address can also by dynamic, based on the interface.
+The following would select IPv4 address currently assigned to the interface:
+.Pp
+.Dl map $ext_if dynamic 10.1.1.0/24 -> ifaddrs($ext_if)
 .Pp
 If the dynamic NAT is configured with multiple translation addresses,
 then a custom selection algorithm can be chosen using the
@@ -587,10 +596,9 @@ $localnet = { 10.1.1.0/24 }
 
 alg "icmp"
 
-# Note: if $ext_if has multiple IP address (e.g. IPv6 as well),
-# then the translation address has to be specified explicitly.
-map $ext_if dynamic 10.1.1.0/24 -> $ext_if
-map $ext_if dynamic proto tcp 10.1.1.2 port 22 <- $ext_if port 9022
+# These NAT rules will dynamically select the interface address(es).
+map $ext_if dynamic 10.1.1.0/24 -> ifaddrs($ext_if)
+map $ext_if dynamic proto tcp 10.1.1.2 port 22 <- ifaddrs($ext_if) port 9022
 
 procedure "log" {
 	# The logging facility can be used together with npfd(8).
@@ -635,7 +643,7 @@ group default {
 .Xr npfctl 8 ,
 .Xr npfd 8
 .Pp
-.Lk http://www.netbsd.org/~rmind/npf/ "NPF documentation website"
+.Lk http://rmind.github.io/npf/ "NPF documentation website"
 .Sh HISTORY
 NPF first appeared in
 .Nx 6.0 .


### PR DESCRIPTION
- Split the _npf_conn_t_ into the two sizes; use separate memory pools for the IPv4 and IPv6 cases.
- Connection state structure (_npf_conn_t_) size is reduced from **248** bytes to: a) **172** bytes for IPv4 connections b) **220** bytes for IPv6 connections. Sizes on the 64-bit architecture.
- Compile the ALGs while here. Misc improvements.