### PR TITLE
Additions and minor corrections to npf.conf.5

### DIFF
--- a/src/npfctl/npf.conf.5
+++ b/src/npfctl/npf.conf.5
@@ -1,6 +1,6 @@
 .\"    $NetBSD: npf.conf.5,v 1.84 2019/01/19 21:19:32 rmind Exp $
 .\"
-.\" Copyright (c) 2009-2018 The NetBSD Foundation, Inc.
+.\" Copyright (c) 2009-2019 The NetBSD Foundation, Inc.
 .\" All rights reserved.
 .\"
 .\" This material is based upon work partially supported by The
@@ -27,7 +27,7 @@
 .\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd January 14, 2019
+.Dd April 6, 2019
 .Dt NPF.CONF 5
 .Os
 .Sh NAME
@@ -61,7 +61,9 @@ map rules for address translation
 .It
 application level gateways
 .It
-procedure definitions to call on filtered packets.
+procedure definitions to call on filtered packets
+.It
+parameter settings.
 .El
 .Sh SYNTAX
 .Ss Variables
@@ -476,6 +478,23 @@ procedure "someproc" {
 .Ed
 .Pp
 In this case, the procedure calls the logging and normalization modules.
+.Ss Parameter settings
+Parameter settings control the behavior of NPF during loading and reloading.
+NPF supports the following parameters:
+.Bl -tag -width "Cm bpf.jit" -offset indent
+.It Cm bpf.jit
+Enable or disable
+.Xr bpfjit 4
+support.
+Some machine architectures are not presently supported by
+.Xr bpfjit 4 .
+Setting this parameter to "off" stops NPF from trying to enable this
+functionality, and generating a warning if it is unable to do so.
+.El
+.Pp
+For example:
+.Pp
+.Dl set bpf.jit off
 .Ss Misc
 Text after a hash
 .Pq Sq #
@@ -638,6 +657,7 @@ group default {
 .\" -----
 .Sh SEE ALSO
 .Xr bpf 4 ,
+.Xr bpfjit 4 ,
 .Xr npf 7 ,
 .Xr pcap-filter 7 ,
 .Xr npfctl 8 ,

--- a/src/npfctl/npf.conf.5
+++ b/src/npfctl/npf.conf.5
@@ -356,8 +356,9 @@ redirecting the public port 9022 to the port 22 of an internal host:
 .Pp
 .Dl map $ext_if dynamic proto tcp 10.1.1.2 port 22 <- $ext_if port 9022
 .Pp
-The translation address can also by dynamic, based on the interface.
-The following would select IPv4 address currently assigned to the interface:
+The translation address can also be dynamic, based on the interface.
+The following would select the IPv4 address currently assigned to the
+interface:
 .Pp
 .Dl map $ext_if dynamic 10.1.1.0/24 -> ifaddrs($ext_if)
 .Pp

--- a/src/npfctl/npf.conf.5
+++ b/src/npfctl/npf.conf.5
@@ -27,7 +27,7 @@
 .\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd April 6, 2019
+.Dd April 7, 2019
 .Dt NPF.CONF 5
 .Os
 .Sh NAME
@@ -479,23 +479,6 @@ procedure "someproc" {
 .Ed
 .Pp
 In this case, the procedure calls the logging and normalization modules.
-.Ss Parameter settings
-Parameter settings control the behavior of NPF during loading and reloading.
-NPF supports the following parameters:
-.Bl -tag -width "Cm bpf.jit" -offset indent
-.It Cm bpf.jit
-Enable or disable
-.Xr bpfjit 4
-support.
-Some machine architectures are not presently supported by
-.Xr bpfjit 4 .
-Setting this parameter to "off" stops NPF from trying to enable this
-functionality, and generating a warning if it is unable to do so.
-.El
-.Pp
-For example:
-.Pp
-.Dl set bpf.jit off
 .Ss Misc
 Text after a hash
 .Pq Sq #
@@ -658,7 +641,6 @@ group default {
 .\" -----
 .Sh SEE ALSO
 .Xr bpf 4 ,
-.Xr bpfjit 4 ,
 .Xr npf 7 ,
 .Xr pcap-filter 7 ,
 .Xr npfctl 8 ,


### PR DESCRIPTION
I'd actually been meaning to submit something like this earlier, then I noticed you've now generalized how parameters can be supplied, so it's probably more relevant in the future. I see the bpf.jit setting is conditionalized to NetBSD only; I assume that doesn't matter so much in the man page, since that's NetBSD-centric by definition. If you prefer something phrased more generally for the Markdown documentation, to be inclusive of non-NetBSD applications, I can try my hand at that, too. Oh, and thanks for creating NPF!