### PR TITLE
Ensure default TCP flags are applied to 'pass stateful all'

### DIFF
--- a/src/npfctl/npf_bpf_comp.c
+++ b/src/npfctl/npf_bpf_comp.c
@@ -565,10 +565,8 @@ npfctl_bpf_tcpfl(npf_bpf_t *ctx, uint8_t tf, uint8_t tf_mask, bool checktcp)
 	};
 	add_insns(ctx, insns_cmp, __arraycount(insns_cmp));
 
-	if (!checktcp) {
-		uint32_t mwords[] = { BM_TCPFL, 2, tf, tf_mask};
-		done_block(ctx, mwords, sizeof(mwords));
-	}
+	uint32_t mwords[] = { BM_TCPFL, 2, tf, tf_mask};
+	done_block(ctx, mwords, sizeof(mwords));
 }
 
 /*

--- a/src/npfctl/npf_build.c
+++ b/src/npfctl/npf_build.c
@@ -363,7 +363,7 @@ static bool
 npfctl_build_code(nl_rule_t *rl, sa_family_t family, const opt_proto_t *op,
     const filt_opts_t *fopts)
 {
-	bool noproto, noaddrs, noports, need_tcpudp = false;
+	bool noproto, noaddrs, noports, nostate, need_tcpudp = false;
 	const addr_port_t *apfrom = &fopts->fo_from;
 	const addr_port_t *apto = &fopts->fo_to;
 	const int proto = op->op_proto;
@@ -375,7 +375,8 @@ npfctl_build_code(nl_rule_t *rl, sa_family_t family, const opt_proto_t *op,
 	noproto = family == AF_UNSPEC && proto == -1 && !op->op_opts;
 	noaddrs = !apfrom->ap_netaddr && !apto->ap_netaddr;
 	noports = !apfrom->ap_portrange && !apto->ap_portrange;
-	if (noproto && noaddrs && noports) {
+	nostate = !(npf_rule_getattr(rl) & NPF_RULE_STATEFUL);
+	if (noproto && noaddrs && noports && nostate) {
 		return false;
 	}
 


### PR DESCRIPTION
The documented default "flags S/SAFR" for stateful rules that affect TCP packets but don't specify any flags, doesn't actually get applied to a rule like "pass stateful out all".  The big problem with this is that when you then do a "block return-rst", that RST packet will create state for the connection it's blocking, so that a second attempt from the same source will pass through.

My modification changes the check, in npfctl_build_code(), for whether we even need to generate any BPF code, so that it will generate code for a rule that's stateful, but doesn't do any explicit filtering: it still needs to apply the default flags check, so code has to be generated. I've tested the code in various ways, including studying the generated BPF byte code for my own various configurations, and verifying that the changes observed are exactly those I'd expect.

While testing this, a configuration with just a single "pass stateful out all" rule, passed through 'npfctl debug', would cause npfctl to crash and dump core. I was already suspicious of the "if (!checktcp)" test at the end of npfctl_bpf_tcpfl() -- why would it need that for a TCP only rule, and not for one covering both TCP and UDP? -- and sure enough, removing the test fixed that problem, with no ill effects observed. I would like someone who knows the code better to sanity check this part of my change, though, as it was done on a hunch, and not based on a thorough understanding of the code.