### PR TITLE
Adjust NPF APIs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Some key features are:
   - NAPT and other forms of port translation (e.g. port forwarding).
   - Inbound and outbound NAT as well as bi-directional NAT.
   - Network-to-network translation, including NETMAP and NPTv6.
+- Carrier-grade NAT (CG-NAT) capability: known to serve over a million connections.
 - Tables for efficient IP sets, including the _longest prefix match_ support.
 - Application Level Gateways (e.g. to support traceroute).
 - NPF uses [BPF with just-in-time (JIT) compilation](https://github.com/rmind/bpfjit).

--- a/dpdk/npf_dpdk.c
+++ b/dpdk/npf_dpdk.c
@@ -71,7 +71,7 @@ npf_dpdk_ifattach(npf_t *npf, const char *name, unsigned idx)
 	ifp->ini.if_name = (char *)(uintptr_t)name;
 	ifp->ini.if_index = idx;
 	LIST_INSERT_HEAD(&dpdk_ifnet_list, ifp, entry);
-	npf_ifmap_attach(npf, ifp);
+	npfk_ifmap_attach(npf, ifp);
 	return ifp;
 }
 
@@ -79,7 +79,7 @@ void
 npf_dpdk_ifdetach(npf_t *npf, ifnet_t *ifp)
 {
 	LIST_REMOVE(ifp, entry);
-	npf_ifmap_detach(npf, ifp);
+	npfk_ifmap_detach(npf, ifp);
 	free(ifp);
 }
 
@@ -208,5 +208,5 @@ static const npf_ifops_t npf_ifops = {
 npf_t *
 npf_dpdk_create(int flags)
 {
-	return npf_create(flags, &npf_mbufops, &npf_ifops);
+	return npfk_create(flags, &npf_mbufops, &npf_ifops);
 }

--- a/dpdk/npf_dpdk_demo.c
+++ b/dpdk/npf_dpdk_demo.c
@@ -141,7 +141,7 @@ load_npf_config(npf_t *npf, nl_config_t *ncf)
 	 * - Note: npf_load() will consume the config.
 	 */
 	config_ref = npf_config_build(ncf);
-	if (npf_load(npf, config_ref, &errinfo) != 0) {
+	if (npfk_load(npf, config_ref, &errinfo) != 0) {
 		errx(EXIT_FAILURE, "npf_load() failed");
 	}
 }
@@ -202,7 +202,7 @@ process_packets(npf_t *npf, struct ifnet *ifp, int di, int *c)
 			continue;
 		}
 
-		ret = npf_packet_handler(npf,
+		ret = npfk_packet_handler(npf,
 		    (struct mbuf **)&in_pkts[i], ifp, di);
 		c[!!ret]++;
 
@@ -230,7 +230,7 @@ main(int argc, char **argv)
 
 	/* Initialise DPDK and NPF. */
 	dpdk_init(argc, argv);
-	npf_sysinit(NWORKERS);
+	npfk_sysinit(NWORKERS);
 	npf_dpdk_init(pktmbuf_pool);
 
 	/* Create a new NPF instance. */
@@ -249,13 +249,13 @@ main(int argc, char **argv)
 	 * Process the packets.  Note: before processing packets,
 	 * each thread doing that must register with NPF instance.
 	 */
-	npf_thread_register(npf);
+	npfk_thread_register(npf);
 	for (unsigned i = 0; i < (16 * 1024); i++) {
 		process_packets(npf, ifp, PFIL_IN, c);
 	}
 	printf("allow\t%d\nblock\t%d\n", c[0], c[1]);
-	npf_thread_unregister(npf);
-	npf_destroy(npf);
-	npf_sysfini();
+	npfk_thread_unregister(npf);
+	npfk_destroy(npf);
+	npfk_sysfini();
 	return 0;
 }

--- a/src/kern/npf.c
+++ b/src/kern/npf.c
@@ -49,7 +49,7 @@ __KERNEL_RCSID(0, "$NetBSD: npf.c,v 1.37 2019/01/19 21:19:31 rmind Exp $");
 static __read_mostly npf_t *	npf_kernel_ctx = NULL;
 
 __dso_public int
-npf_sysinit(unsigned nworkers)
+npfk_sysinit(unsigned nworkers)
 {
 	npf_bpf_sysinit();
 	npf_tableset_sysinit();
@@ -58,7 +58,7 @@ npf_sysinit(unsigned nworkers)
 }
 
 __dso_public void
-npf_sysfini(void)
+npfk_sysfini(void)
 {
 	npf_worker_sysfini();
 	npf_nat_sysfini();
@@ -67,7 +67,7 @@ npf_sysfini(void)
 }
 
 __dso_public npf_t *
-npf_create(int flags, const npf_mbufops_t *mbufops, const npf_ifops_t *ifops)
+npfk_create(int flags, const npf_mbufops_t *mbufops, const npf_ifops_t *ifops)
 {
 	npf_t *npf;
 
@@ -94,7 +94,7 @@ npf_create(int flags, const npf_mbufops_t *mbufops, const npf_ifops_t *ifops)
 }
 
 __dso_public void
-npf_destroy(npf_t *npf)
+npfk_destroy(npf_t *npf)
 {
 	/*
 	 * Destroy the current configuration.  Note: at this point all
@@ -117,25 +117,25 @@ npf_destroy(npf_t *npf)
 }
 
 __dso_public int
-npf_load(npf_t *npf, void *config_ref, npf_error_t *err)
+npfk_load(npf_t *npf, void *config_ref, npf_error_t *err)
 {
 	return npfctl_load(npf, 0, config_ref);
 }
 
 __dso_public void
-npf_gc(npf_t *npf)
+npfk_gc(npf_t *npf)
 {
 	npf_conn_worker(npf);
 }
 
 __dso_public void
-npf_thread_register(npf_t *npf)
+npfk_thread_register(npf_t *npf)
 {
 	pserialize_register(npf->qsbr);
 }
 
 __dso_public void
-npf_thread_unregister(npf_t *npf)
+npfk_thread_unregister(npf_t *npf)
 {
 	pserialize_perform(npf->qsbr);
 	pserialize_unregister(npf->qsbr);
@@ -198,14 +198,14 @@ npf_stats_clear_cb(void *mem, void *arg, struct cpu_info *ci)
  */
 
 __dso_public void
-npf_stats(npf_t *npf, uint64_t *buf)
+npfk_stats(npf_t *npf, uint64_t *buf)
 {
 	memset(buf, 0, NPF_STATS_SIZE);
 	percpu_foreach(npf->stats_percpu, npf_stats_collect, buf);
 }
 
 __dso_public void
-npf_stats_clear(npf_t *npf)
+npfk_stats_clear(npf_t *npf)
 {
 	percpu_foreach(npf->stats_percpu, npf_stats_clear_cb, NULL);
 }

--- a/src/kern/npf_conf.c
+++ b/src/kern/npf_conf.c
@@ -169,7 +169,7 @@ npf_config_load(npf_t *npf, npf_ruleset_t *rset, npf_tableset_t *tset,
 	/* Synchronise: drain all references. */
 	pserialize_perform(npf->qsbr);
 	if (flush) {
-		npf_portmap_flush(npf);
+		npf_portmap_flush(npf->portmap);
 		npf_ifmap_flush(npf);
 	}
 

--- a/src/kern/npf_conn.h
+++ b/src/kern/npf_conn.h
@@ -38,8 +38,6 @@
 
 #include "npf_impl.h"
 
-typedef struct npf_connkey npf_connkey_t;
-
 #if defined(__NPF_CONN_PRIVATE)
 
 /*
@@ -91,6 +89,8 @@ struct npf_conn {
 	uint32_t		c_keys[];
 };
 
+#endif
+
 /*
  * Connection key interface.
  *
@@ -104,10 +104,10 @@ struct npf_conn {
 #define	NPF_CONNKEY_ALEN(key)	((key)->ck_key[0] & 0xffff)
 #define	NPF_CONNKEY_LEN(key)	(8 + (NPF_CONNKEY_ALEN(key) * 2))
 
-struct npf_connkey {
+typedef struct npf_connkey {
 	/* Warning: ck_key has a variable length -- see above. */
 	uint32_t		ck_key[NPF_CONNKEY_MAXWORDS];
-};
+} npf_connkey_t;
 
 unsigned	npf_conn_conkey(const npf_cache_t *, npf_connkey_t *, bool);
 npf_connkey_t *	npf_conn_getforwkey(npf_conn_t *);
@@ -118,8 +118,6 @@ void		npf_conn_adjkey(npf_connkey_t *, const npf_addr_t *,
 unsigned	npf_connkey_import(const nvlist_t *, npf_connkey_t *);
 nvlist_t *	npf_connkey_export(const npf_connkey_t *);
 void		npf_connkey_print(const npf_connkey_t *);
-
-#endif
 
 /*
  * Connection tracking interface.
@@ -140,7 +138,7 @@ bool		npf_conn_pass(const npf_conn_t *, npf_match_info_t *,
 void		npf_conn_setpass(npf_conn_t *, const npf_match_info_t *,
 		    npf_rproc_t *);
 int		npf_conn_setnat(const npf_cache_t *, npf_conn_t *,
-		    npf_nat_t *, u_int);
+		    npf_nat_t *, unsigned);
 npf_nat_t *	npf_conn_getnat(npf_conn_t *, const int, bool *);
 bool		npf_conn_expired(npf_t *, const npf_conn_t *, uint64_t);
 void		npf_conn_remove(npf_conndb_t *, npf_conn_t *);

--- a/src/kern/npf_ctl.c
+++ b/src/kern/npf_ctl.c
@@ -121,7 +121,7 @@ npf_mk_params(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict, bool set)
 		val = (int)nvlist_get_number(params, name);
 		if (set) {
 			/* Actually set the parameter. */
-			error = npf_param_set(npf, name, val);
+			error = npfk_param_set(npf, name, val);
 			KASSERT(error == 0);
 			continue;
 		}

--- a/src/kern/npf_handler.c
+++ b/src/kern/npf_handler.c
@@ -112,12 +112,12 @@ npf_reassembly(npf_t *npf, npf_cache_t *npc, bool *mff)
 }
 
 /*
- * npf_packet_handler: main packet handling routine for layer 3.
+ * npfk_packet_handler: main packet handling routine for layer 3.
  *
  * Note: packet flow and inspection logic is in strict order.
  */
 __dso_public int
-npf_packet_handler(npf_t *npf, struct mbuf **mp, ifnet_t *ifp, int di)
+npfk_packet_handler(npf_t *npf, struct mbuf **mp, ifnet_t *ifp, int di)
 {
 	nbuf_t nbuf;
 	npf_cache_t npc;

--- a/src/kern/npf_if.c
+++ b/src/kern/npf_if.c
@@ -181,7 +181,7 @@ npf_ifmap_getname(npf_t *npf, const u_int id)
 }
 
 __dso_public void
-npf_ifmap_attach(npf_t *npf, ifnet_t *ifp)
+npfk_ifmap_attach(npf_t *npf, ifnet_t *ifp)
 {
 	const npf_ifops_t *ifops = npf->ifops;
 	u_int i;
@@ -193,7 +193,7 @@ npf_ifmap_attach(npf_t *npf, ifnet_t *ifp)
 }
 
 __dso_public void
-npf_ifmap_detach(npf_t *npf, ifnet_t *ifp)
+npfk_ifmap_detach(npf_t *npf, ifnet_t *ifp)
 {
 	/* Diagnostic. */
 	npf_config_enter(npf);

--- a/src/kern/npf_impl.h
+++ b/src/kern/npf_impl.h
@@ -185,7 +185,6 @@ typedef enum {
 	NPF_PARAMS_CONNDB = 0,
 	NPF_PARAMS_GENERIC_STATE,
 	NPF_PARAMS_TCP_STATE,
-	NPF_PARAMS_PORTMAP,
 	NPF_PARAMS_COUNT
 } npf_paramgroup_t;
 
@@ -461,10 +460,13 @@ int		npf_state_tcp_timeout(npf_t *, const npf_state_t *);
 void		npf_portmap_init(npf_t *);
 void		npf_portmap_fini(npf_t *);
 
-in_port_t	npf_portmap_get(npf_t *, int, const npf_addr_t *);
-bool		npf_portmap_take(npf_t *, int, const npf_addr_t *, in_port_t);
-void		npf_portmap_put(npf_t *, int, const npf_addr_t *, in_port_t);
-void		npf_portmap_flush(npf_t *);
+npf_portmap_t *	npf_portmap_create(void);
+void		npf_portmap_destroy(npf_portmap_t *);
+
+in_port_t	npf_portmap_get(npf_portmap_t *, int, const npf_addr_t *);
+bool		npf_portmap_take(npf_portmap_t *, int, const npf_addr_t *, in_port_t);
+void		npf_portmap_put(npf_portmap_t *, int, const npf_addr_t *, in_port_t);
+void		npf_portmap_flush(npf_portmap_t *);
 
 /* NAT. */
 void		npf_nat_sysinit(void);

--- a/src/kern/npf_nat.c
+++ b/src/kern/npf_nat.c
@@ -514,7 +514,8 @@ npf_nat_create(npf_cache_t *npc, npf_natpolicy_t *np, npf_conn_t *con)
 
 	/* Get a new port for translation. */
 	if ((np->n_flags & NPF_NAT_PORTMAP) != 0) {
-		nt->nt_tport = npf_portmap_get(np->n_npfctx, alen, taddr);
+		npf_portmap_t *pm = np->n_npfctx->portmap;
+		nt->nt_tport = npf_portmap_get(pm, alen, taddr);
 	} else {
 		nt->nt_tport = np->n_tport;
 	}
@@ -745,7 +746,8 @@ npf_nat_destroy(npf_nat_t *nt)
 
 	/* Return taken port to the portmap. */
 	if ((np->n_flags & NPF_NAT_PORTMAP) != 0 && nt->nt_tport) {
-		npf_portmap_put(npf, nt->nt_alen, &nt->nt_taddr, nt->nt_tport);
+		npf_portmap_t *pm = npf->portmap;
+		npf_portmap_put(pm, nt->nt_alen, &nt->nt_taddr, nt->nt_tport);
 	}
 	npf_stats_inc(np->n_npfctx, NPF_STAT_NAT_DESTROY);
 
@@ -804,10 +806,14 @@ npf_nat_import(npf_t *npf, const nvlist_t *nat,
 	nt->nt_tport = dnvlist_get_number(nat, "tport", 0);
 
 	/* Take a specific port from port-map. */
-	if ((np->n_flags & NPF_NAT_PORTMAP) != 0 && nt->nt_tport &&
-	    !npf_portmap_take(npf, nt->nt_alen, &nt->nt_taddr, nt->nt_tport)) {
-		pool_cache_put(nat_cache, nt);
-		return NULL;
+	if ((np->n_flags & NPF_NAT_PORTMAP) != 0 && nt->nt_tport) {
+		npf_portmap_t *pm = npf->portmap;
+
+		if (!npf_portmap_take(pm, nt->nt_alen,
+		    &nt->nt_taddr, nt->nt_tport)) {
+			pool_cache_put(nat_cache, nt);
+			return NULL;
+		}
 	}
 	npf_stats_inc(npf, NPF_STAT_NAT_CREATE);
 

--- a/src/kern/npf_os.c
+++ b/src/kern/npf_os.c
@@ -219,7 +219,7 @@ npf_stats_export(npf_t *npf, void *data)
 	int error;
 
 	fullst = kmem_alloc(NPF_STATS_SIZE, KM_SLEEP);
-	npf_stats(npf, fullst); /* will zero the buffer */
+	npfk_stats(npf, fullst); /* will zero the buffer */
 	error = copyout(fullst, uptr, NPF_STATS_SIZE);
 	kmem_free(fullst, NPF_STATS_SIZE);
 	return error;
@@ -337,10 +337,10 @@ npf_ifop_setmeta(ifnet_t *ifp, void *arg)
  * Wrapper of the main packet handler to pass the kernel NPF context.
  */
 static int
-npfkern_packet_handler(void *arg, struct mbuf **mp, ifnet_t *ifp, int di)
+npfos_packet_handler(void *arg, struct mbuf **mp, ifnet_t *ifp, int di)
 {
 	npf_t *npf = npf_getkernctx();
-	return npf_packet_handler(npf, mp, ifp, di);
+	return npfk_packet_handler(npf, mp, ifp, di);
 }
 
 /*
@@ -434,12 +434,12 @@ npf_pfil_register(bool init)
 
 	/* Packet IN/OUT handlers for IP layer. */
 	if (npf_ph_inet) {
-		error = pfil_add_hook(npfkern_packet_handler, npf,
+		error = pfil_add_hook(npfos_packet_handler, npf,
 		    PFIL_ALL, npf_ph_inet);
 		KASSERT(error == 0);
 	}
 	if (npf_ph_inet6) {
-		error = pfil_add_hook(npfkern_packet_handler, npf,
+		error = pfil_add_hook(npfos_packet_handler, npf,
 		    PFIL_ALL, npf_ph_inet6);
 		KASSERT(error == 0);
 	}
@@ -473,11 +473,11 @@ npf_pfil_unregister(bool fini)
 		    PFIL_IFADDR, npf_ph_if);
 	}
 	if (npf_ph_inet) {
-		(void)pfil_remove_hook(npfkern_packet_handler, npf,
+		(void)pfil_remove_hook(npfos_packet_handler, npf,
 		    PFIL_ALL, npf_ph_inet);
 	}
 	if (npf_ph_inet6) {
-		(void)pfil_remove_hook(npfkern_packet_handler, npf,
+		(void)pfil_remove_hook(npfos_packet_handler, npf,
 		    PFIL_ALL, npf_ph_inet6);
 	}
 	pfil_registered = false;

--- a/src/kern/npf_params.c
+++ b/src/kern/npf_params.c
@@ -175,7 +175,7 @@ npf_param_check(npf_t *npf, const char *name, int val)
 }
 
 __dso_public int
-npf_param_get(npf_t *npf, const char *name, int *val)
+npfk_param_get(npf_t *npf, const char *name, int *val)
 {
 	npf_param_t *param;
 
@@ -187,7 +187,7 @@ npf_param_get(npf_t *npf, const char *name, int *val)
 }
 
 __dso_public int
-npf_param_set(npf_t *npf, const char *name, int val)
+npfk_param_set(npf_t *npf, const char *name, int val)
 {
 	npf_param_t *param;
 

--- a/src/kern/npf_portmap.c
+++ b/src/kern/npf_portmap.c
@@ -99,48 +99,57 @@ struct npf_portmap {
 	thmap_t	*		addr_map;
 	LIST_HEAD(, bitmap)	bitmap_list;
 	kmutex_t		list_lock;
+	int			min_port;
+	int			max_port;
 };
 
 typedef struct {
-	int		min_port;
-	int		max_port;
 } npf_portmap_params_t;
 
 void
 npf_portmap_init(npf_t *npf)
 {
-	npf_portmap_params_t *params = npf_param_allocgroup(npf,
-	    NPF_PARAMS_PORTMAP, sizeof(npf_portmap_params_t));
+	npf_portmap_t *pm = npf_portmap_create();
 	npf_param_t param_map[] = {
 		{
 			"portmap.min_port",
-			&params->min_port,
+			&pm->min_port,
 			.default_val = 1024,
 			.min = 1024, .max = 65535
 		},
 		{
 			"portmap.max_port",
-			&params->max_port,
+			&pm->max_port,
 			.default_val = 65535,
 			.min = 1024, .max = 65535
 		}
 	};
 	npf_param_register(npf, param_map, __arraycount(param_map));
-
-	npf->portmap = kmem_zalloc(sizeof(npf_portmap_t), KM_SLEEP);
-	mutex_init(&npf->portmap->list_lock, MUTEX_DEFAULT, IPL_SOFTNET);
-	npf->portmap->addr_map = thmap_create(0, NULL, THMAP_NOCOPY);
+	npf->portmap = pm;
 }
 
 void
 npf_portmap_fini(npf_t *npf)
 {
-	const size_t len = sizeof(npf_portmap_params_t);
-	npf_portmap_t *pm = npf->portmap;
+	npf_portmap_destroy(npf->portmap);
+	npf->portmap = NULL; // diagnostic
+}
 
-	npf_param_freegroup(npf, NPF_PARAMS_PORTMAP, len);
+npf_portmap_t *
+npf_portmap_create(void)
+{
+	npf_portmap_t *pm;
 
-	npf_portmap_flush(npf);
+	pm = kmem_zalloc(sizeof(npf_portmap_t), KM_SLEEP);
+	mutex_init(&pm->list_lock, MUTEX_DEFAULT, IPL_SOFTNET);
+	pm->addr_map = thmap_create(0, NULL, THMAP_NOCOPY);
+	return pm;
+}
+
+void
+npf_portmap_destroy(npf_portmap_t *pm)
+{
+	npf_portmap_flush(pm);
 	KASSERT(LIST_EMPTY(&pm->bitmap_list));
 
 	thmap_destroy(pm->addr_map);
@@ -381,9 +390,8 @@ again:
 /////////////////////////////////////////////////////////////////////////
 
 static bitmap_t *
-npf_portmap_autoget(npf_t *npf, unsigned alen, const npf_addr_t *addr)
+npf_portmap_autoget(npf_portmap_t *pm, unsigned alen, const npf_addr_t *addr)
 {
-	npf_portmap_t *pm = npf->portmap;
 	bitmap_t *bm;
 
 	KASSERT(pm && pm->addr_map);
@@ -431,9 +439,8 @@ npf_portmap_autoget(npf_t *npf, unsigned alen, const npf_addr_t *addr)
  * need to acquire locks.
  */
 void
-npf_portmap_flush(npf_t *npf)
+npf_portmap_flush(npf_portmap_t *pm)
 {
-	npf_portmap_t *pm = npf->portmap;
 	bitmap_t *bm;
 
 	while ((bm = LIST_FIRST(&pm->bitmap_list)) != NULL) {
@@ -461,28 +468,27 @@ npf_portmap_flush(npf_t *npf)
  * => Zero indicates a failure.
  */
 in_port_t
-npf_portmap_get(npf_t *npf, int alen, const npf_addr_t *addr)
+npf_portmap_get(npf_portmap_t *pm, int alen, const npf_addr_t *addr)
 {
-	const npf_portmap_params_t *params = npf->params[NPF_PARAMS_PORTMAP];
-	const unsigned port_delta = params->max_port - params->min_port;
+	const unsigned port_delta = pm->max_port - pm->min_port;
 	unsigned bit, target;
 	bitmap_t *bm;
 
-	bm = npf_portmap_autoget(npf, alen, addr);
+	bm = npf_portmap_autoget(pm, alen, addr);
 	if (bm == NULL) {
 		/* No memory. */
 		return 0;
 	}
 
 	/* Randomly select a port. */
-	target = params->min_port + (cprng_fast32() % port_delta);
+	target = pm->min_port + (cprng_fast32() % port_delta);
 	bit = target;
 next:
 	if (bitmap_set(bm, bit)) {
 		/* Success. */
 		return htons(bit);
 	}
-	bit = params->min_port + ((bit + 1) % port_delta);
+	bit = pm->min_port + ((bit + 1) % port_delta);
 	if (target != bit) {
 		/* Next.. */
 		goto next;
@@ -495,13 +501,13 @@ next:
  * npf_portmap_take: allocate a specific port in the portmap.
  */
 bool
-npf_portmap_take(npf_t *npf, int alen, const npf_addr_t *addr, in_port_t port)
+npf_portmap_take(npf_portmap_t *pm, int alen,
+    const npf_addr_t *addr, in_port_t port)
 {
-	const npf_portmap_params_t *params = npf->params[NPF_PARAMS_PORTMAP];
-	bitmap_t *bm = npf_portmap_autoget(npf, alen, addr);
+	bitmap_t *bm = npf_portmap_autoget(pm, alen, addr);
 
 	port = ntohs(port);
-	if (!bm || port < params->min_port || port > params->max_port) {
+	if (!bm || port < pm->min_port || port > pm->max_port) {
 		/* Out of memory / invalid port. */
 		return false;
 	}
@@ -514,11 +520,12 @@ npf_portmap_take(npf_t *npf, int alen, const npf_addr_t *addr, in_port_t port)
  * => The port value should be in network byte-order.
  */
 void
-npf_portmap_put(npf_t *npf, int alen, const npf_addr_t *addr, in_port_t port)
+npf_portmap_put(npf_portmap_t *pm, int alen,
+    const npf_addr_t *addr, in_port_t port)
 {
 	bitmap_t *bm;
 
-	bm = npf_portmap_autoget(npf, alen, addr);
+	bm = npf_portmap_autoget(pm, alen, addr);
 	if (bm) {
 		port = ntohs(port);
 		bitmap_clr(bm, port);

--- a/src/kern/npf_worker.c
+++ b/src/kern/npf_worker.c
@@ -198,7 +198,7 @@ npf_worker(void *arg)
 			npf_workfunc_t work;
 
 			if (!npf->sync_registered) {
-				npf_thread_register(npf);
+				npfk_thread_register(npf);
 				npf->sync_registered = true;
 			}
 

--- a/src/kern/npfkern.3
+++ b/src/kern/npfkern.3
@@ -36,35 +36,37 @@
 .In net/npfkern.h
 .\" ---
 .Ft int
-.Fn npf_sysinit "unsigned nworkers"
+.Fn npfk_sysinit "unsigned nworkers"
 .Ft void
-.Fn npf_sysfini "void"
+.Fn npfk_sysfini "void"
 .Ft npf_t *
-.Fn npf_create "int flags" "const npf_mbufops_t *mbufops" "const npf_ifops_t *ifops"
+.Fn npfk_create "int flags" "const npf_mbufops_t *mbufops" \
+"const npf_ifops_t *ifops"
 .Ft int
-.Fn npf_load "npf_t *npf" "void *ref" "npf_error_t *err"
+.Fn npfk_load "npf_t *npf" "void *ref" "npf_error_t *err"
 .Ft void
-.Fn npf_gc "npf_t *npf"
+.Fn npfk_gc "npf_t *npf"
 .Ft void
-.Fn npf_destroy "npf_t *npf"
+.Fn npfk_destroy "npf_t *npf"
 .Ft void
-.Fn npf_thread_register "npf_t *npf"
+.Fn npfk_thread_register "npf_t *npf"
 .Ft void
-.Fn npf_thread_unregister "npf_t *npf"
+.Fn npfk_thread_unregister "npf_t *npf"
 .Ft int
-.Fn npf_packet_handler "npf_t *npf" "struct mbuf **mp" "struct ifnet *ifp" "int di"
+.Fn npfk_packet_handler "npf_t *npf" "struct mbuf **mp" \
+"struct ifnet *ifp" "int di"
 .Ft void
-.Fn npf_ifmap_attach "npf_t *npf" "struct ifnet *ifp"
+.Fn npfk_ifmap_attach "npf_t *npf" "struct ifnet *ifp"
 .Ft void
-.Fn npf_ifmap_detach "npf_t *npf" "struct ifnet *ifp"
+.Fn npfk_ifmap_detach "npf_t *npf" "struct ifnet *ifp"
 .Ft int
-.Fn npf_param_get "npf_t *npf" "const char *name" "int64_t *val"
+.Fn npfk_param_get "npf_t *npf" "const char *name" "int64_t *val"
 .Ft int
-.Fn npf_param_set "npf_t *npf" "const char *name" "int64_t val"
+.Fn npfk_param_set "npf_t *npf" "const char *name" "int64_t val"
 .Ft void
-.Fn npf_stats "npf_t *npf" "uint64_t *buf"
+.Fn npfk_stats "npf_t *npf" "uint64_t *buf"
 .Ft void
-.Fn npf_stats_clear "npf_t *npf"
+.Fn npfk_stats_clear "npf_t *npf"
 .\" -----
 .Sh DESCRIPTION
 The
@@ -74,7 +76,7 @@ library provides an interface to kernel component of the NPF packet filter.
 .Sh FUNCTIONS
 .Bl -tag -width 4n
 .\" ---
-.It Fn npf_sysinit "nworkers"
+.It Fn npfk_sysinit "nworkers"
 Initialize the NPF kernel component system.
 This must be called before starting the use of
 .Nm
@@ -87,13 +89,13 @@ amongst all the instances.
 .Pp
 Returns zero on success and the error number on failure.
 .\" ---
-.It Fn npf_sysfini
+.It Fn npfk_sysfini
 Destroy any resources used by the
 .Fm
 library, e.g. stop and exit the worker threads.
 This function must be called once finished using the component.
 .\" ---
-.It Fn npf_create "flags" "mbufops" "ifops"
+.It Fn npfk_create "flags" "mbufops" "ifops"
 Construct and return a new instance of the NPF kernel component.
 The parameter
 .Fa flags
@@ -115,18 +117,18 @@ Returns a reference (pointer) to the instance on success and
 .Dv NULL
 on failure.
 .\" ---
-.It Fn npf_gc "npf"
+.It Fn npfk_gc "npf"
 Perform the garbage collection of connection and/or any other objects
 related to the specified NPF instance.
 This routine should only be used if the instance was created with
 .Dv NPF_NO_GC
 flag.
 .\" ---
-.It Fn npf_destroy "npf"
+.It Fn npfk_destroy "npf"
 Destroy the instance of the NPF kernel compaining, freeing all resources
 used by it.
 .\" ---
-.It Fn npf_load "npf" "ref" "err"
+.It Fn npfk_load "npf" "ref" "err"
 Load a new configuration into the NPF instance.
 The new configuration is specified by a
 .Fa ref
@@ -143,21 +145,21 @@ structure specified by the
 .Fa err
 parameter.
 .\" ---
-.It Fn npf_thread_register "npf"
+.It Fn npfk_thread_register "npf"
 Register a "processing context" i.e. a thread which will perform the
-.Fn npf_packet_handler
+.Fn npfk_packet_handler
 calls.
 All threads processing packets (invoking the handler) must register;
 all registered threads must also remove themselves from the register
 using before exit using the
-.Fa npf_thread_unregister
+.Fa npfk_thread_unregister
 routine.
 Failure to register may result in undefined behaviour.
 .\" ---
-.It Fn npf_thread_unregister "npf"
+.It Fn npfk_thread_unregister "npf"
 Remove the thread from the register of threads which process the packets.
 .\" ---
-.It Fn npf_packet_handler "npf" "mp" "ifp" "di"
+.It Fn npfk_packet_handler "npf" "mp" "ifp" "di"
 Inspect the packet, matching and processing it against the configuration
 loaded in the specified NPF instance.
 This is the main routine performing packet filtering (as well as any other
@@ -186,26 +188,26 @@ A regular "block" is indicated by the
 .Dv ENETUNREACH
 error nubmer.
 .\" ---
-.It Fn npf_ifmap_attach "npf" "ifp"
+.It Fn npfk_ifmap_attach "npf" "ifp"
 Attach the virtual network interface to the NPF instance.
 This indicates that the packets on this interface shall be processed.
-.It Fn npf_ifmap_detach "npf" "ifp"
+.It Fn npfk_ifmap_detach "npf" "ifp"
 Detach the virtual network interface from the NPF instance.
 .\" ---
-.It Fn npf_param_get "npf" "name" "valp"
+.It Fn npfk_param_get "npf" "name" "valp"
 Get the parameter value of the given NPF instance.
 On success, the function returns zero and the parameter value stored in
 .Fa valp .
 On failure, if the parameter does not exist, the function returns
 .Dv ENOENT .
 .\" ---
-.It Fn npf_param_set "npf" "name" "val"
+.It Fn npfk_param_set "npf" "name" "val"
 Set the parameter vale for the given NPF instance.
 Returns zero on success or
 .Dv ENOENT
 if the parameter does not exist.
 .\" ---
-.It Fn npf_stats "npf" "buf"
+.It Fn npfk_stats "npf" "buf"
 Get the statistics of the NPF instance into the buffer specified by the
 .Fa buf
 parameter.
@@ -218,7 +220,7 @@ number of elements (or
 .Dv NPF_STATS_SIZE
 in bytes).
 .\" ---
-.It Fn npf_stats_clear "npf"
+.It Fn npfk_stats_clear "npf"
 Clear (by resetting to zero) the statistics of the given NPF instance.
 .\" ---
 .El

--- a/src/kern/npfkern.h
+++ b/src/kern/npfkern.h
@@ -61,23 +61,23 @@ typedef struct {
 	bool		(*ensure_writable)(struct mbuf **, size_t);
 } npf_mbufops_t;
 
-int	npf_sysinit(unsigned);
-void	npf_sysfini(void);
+int	npfk_sysinit(unsigned);
+void	npfk_sysfini(void);
 
-npf_t *	npf_create(int, const npf_mbufops_t *, const npf_ifops_t *);
-int	npf_load(npf_t *, void *, npf_error_t *);
-void	npf_gc(npf_t *);
-void	npf_destroy(npf_t *);
+npf_t *	npfk_create(int, const npf_mbufops_t *, const npf_ifops_t *);
+int	npfk_load(npf_t *, void *, npf_error_t *);
+void	npfk_gc(npf_t *);
+void	npfk_destroy(npf_t *);
 
-void	npf_thread_register(npf_t *);
-void	npf_thread_unregister(npf_t *);
-int	npf_packet_handler(npf_t *, struct mbuf **, struct ifnet *, int);
-void	npf_ifmap_attach(npf_t *, struct ifnet *);
-void	npf_ifmap_detach(npf_t *, struct ifnet *);
-int	npf_param_get(npf_t *, const char *, int *);
-int	npf_param_set(npf_t *, const char *, int);
-void	npf_stats(npf_t *, uint64_t *);
-void	npf_stats_clear(npf_t *);
+void	npfk_thread_register(npf_t *);
+void	npfk_thread_unregister(npf_t *);
+int	npfk_packet_handler(npf_t *, struct mbuf **, struct ifnet *, int);
+void	npfk_ifmap_attach(npf_t *, struct ifnet *);
+void	npfk_ifmap_detach(npf_t *, struct ifnet *);
+int	npfk_param_get(npf_t *, const char *, int *);
+int	npfk_param_set(npf_t *, const char *, int);
+void	npfk_stats(npf_t *, uint64_t *);
+void	npfk_stats_clear(npf_t *);
 
 /*
  * ALGs.

--- a/src/npftest/libnpftest/npf_conn_test.c
+++ b/src/npftest/libnpftest/npf_conn_test.c
@@ -113,7 +113,7 @@ run_gc_tests(void)
 	int val;
 
 	/* Check the default value. */
-	npf_param_get(npf_getkernctx(), "gc.step", &val);
+	npfk_param_get(npf_getkernctx(), "gc.step", &val);
 	CHECK_TRUE(val == 256);
 
 	/* Empty => GC => 0 in conndb. */
@@ -145,7 +145,7 @@ run_gc_tests(void)
 	CHECK_TRUE(ok);
 
 	/* 512 expired => GC => 127 in conndb. */
-	npf_param_set(npf_getkernctx(), "gc.step", 128);
+	npfk_param_set(npf_getkernctx(), "gc.step", 128);
 	ok = run_conn_gc(0, 512, 384);
 	CHECK_TRUE(ok);
 

--- a/src/npftest/libnpftest/npf_nat_test.c
+++ b/src/npftest/libnpftest/npf_nat_test.c
@@ -231,7 +231,7 @@ npf_nat_test(bool verbose)
 		}
 		m = mbuf_get_pkt(t->af, IPPROTO_UDP,
 		    t->src, t->dst, t->sport, t->dport);
-		error = npf_packet_handler(npf, &m, ifp, t->di);
+		error = npfk_packet_handler(npf, &m, ifp, t->di);
 		ret = checkresult(verbose, i, m, ifp, error);
 		if (m) {
 			m_freem(m);

--- a/src/npftest/libnpftest/npf_perf_test.c
+++ b/src/npftest/libnpftest/npf_perf_test.c
@@ -42,7 +42,7 @@ worker(void *arg)
 	while (!done) {
 		int error;
 
-		error = npf_packet_handler(npf, &m, ifp, PFIL_OUT);
+		error = npfk_packet_handler(npf, &m, ifp, PFIL_OUT);
 		KASSERT(error == 0); (void)error;
 		n++;
 	}

--- a/src/npftest/libnpftest/npf_rule_test.c
+++ b/src/npftest/libnpftest/npf_rule_test.c
@@ -92,7 +92,7 @@ run_handler_testcase(unsigned i)
 	int error;
 
 	m = mbuf_get_pkt(AF_INET, IPPROTO_UDP, t->src, t->dst, 9000, 9000);
-	error = npf_packet_handler(npf, &m, ifp, t->di);
+	error = npfk_packet_handler(npf, &m, ifp, t->di);
 	if (m) {
 		m_freem(m);
 	}

--- a/src/npftest/libnpftest/npf_test_subr.c
+++ b/src/npftest/libnpftest/npf_test_subr.c
@@ -63,9 +63,9 @@ npf_test_init(int (*pton_func)(int, const char *, void *),
 {
 	npf_t *npf;
 
-	npf_sysinit(0);
-	npf = npf_create(0, &npftest_mbufops, &npftest_ifops);
-	npf_thread_register(npf);
+	npfk_sysinit(0);
+	npf = npfk_create(0, &npftest_mbufops, &npftest_ifops);
+	npfk_thread_register(npf);
 	npf_setkernctx(npf);
 
 	npf_state_setsampler(npf_state_sample);
@@ -80,9 +80,9 @@ void
 npf_test_fini(void)
 {
 	npf_t *npf = npf_getkernctx();
-	npf_thread_unregister(npf);
-	npf_destroy(npf);
-	npf_sysfini();
+	npfk_thread_unregister(npf);
+	npfk_destroy(npf);
+	npfk_sysfini();
 }
 
 int
@@ -99,7 +99,7 @@ npf_test_load(const void *buf, size_t len, bool verbose)
 	load_npf_config_ifs(npf_dict, verbose);
 
 	// Note: npf_dict will be consumed by npf_load().
-	return npf_load(npf_getkernctx(), npf_dict, &error);
+	return npfk_load(npf_getkernctx(), npf_dict, &error);
 }
 
 ifnet_t *
@@ -116,7 +116,7 @@ npf_test_addif(const char *ifname, bool reg, bool verbose)
 	strlcpy(ifp->if_xname, ifname, sizeof(ifp->if_xname));
 	TAILQ_INSERT_TAIL(&npftest_ifnet_list, ifp, if_list);
 
-	npf_ifmap_attach(npf, ifp);
+	npfk_ifmap_attach(npf, ifp);
 	if (reg) {
 		npf_ifmap_register(npf, ifname);
 	}
@@ -212,7 +212,7 @@ npf_test_statetrack(const void *data, size_t len, ifnet_t *ifp,
 	int i = 0, error;
 
 	m = mbuf_getwithdata(data, len);
-	error = npf_packet_handler(npf, &m, ifp, forw ? PFIL_OUT : PFIL_IN);
+	error = npfk_packet_handler(npf, &m, ifp, forw ? PFIL_OUT : PFIL_IN);
 	if (error) {
 		assert(m == NULL);
 		return error;


### PR DESCRIPTION
- npfkern: use the npfk_ prefix for public API.
- NPF portmap: amend the API, so it can be used elsewhere.
- Make npf_connkey_t public.