### PR TITLE
Implement npfctl table replace subcommand. (#52)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -341,8 +341,9 @@ Usage:	npfctl start | stop | flush | show | stats
 	npfctl rule "rule-name" { add | rem } <rule-syntax>
 	npfctl rule "rule-name" rem-id <rule-id>
 	npfctl rule "rule-name" { list | flush }
-	npfctl table <tid> { add | rem | test } <address/mask>
-	npfctl table <tid> { list | flush }
+	npfctl table "table-name" { add | rem | test } <address/mask>
+	npfctl table "table-name" { list | flush }
+	npfctl table "table-name" replace [-n "name"] [-t <type>] <table-file>
 	npfctl save | load
 	npfctl list [-46hNnw] [-i <ifname>]
 	npfctl debug [<rule-file>] [<raw-output>]

--- a/src/npfctl/npf_build.c
+++ b/src/npfctl/npf_build.c
@@ -151,25 +151,32 @@ npfctl_debug_addif(const char *ifname)
 	return 0;
 }
 
-unsigned
-npfctl_table_getid(const char *name)
+nl_table_t *
+npfctl_table_getbyname(nl_config_t *ncf, const char *name)
 {
-	unsigned tid = (unsigned)-1;
 	nl_iter_t i = NPF_ITER_BEGIN;
 	nl_table_t *tl;
 
 	/* XXX dynamic ruleset */
-	if (!npf_conf) {
-		return (unsigned)-1;
+	if (!ncf) {
+		return NULL;
 	}
-	while ((tl = npf_table_iterate(npf_conf, &i)) != NULL) {
+	while ((tl = npf_table_iterate(ncf, &i)) != NULL) {
 		const char *tname = npf_table_getname(tl);
 		if (strcmp(tname, name) == 0) {
-			tid = npf_table_getid(tl);
 			break;
 		}
 	}
-	return tid;
+	return tl;
+}
+
+unsigned
+npfctl_table_getid(const char *name)
+{
+	nl_table_t *tl;
+
+	tl = npfctl_table_getbyname(npf_conf, name);
+	return tl ? npf_table_getid(tl) : (unsigned)-1;
 }
 
 const char *
@@ -873,15 +880,13 @@ npfctl_build_natseg(int sd, int type, unsigned mflags, const char *ifname,
  * npfctl_fill_table: fill NPF table with entries from a specified file.
  */
 static void
-npfctl_fill_table(nl_table_t *tl, u_int type, const char *fname)
+npfctl_fill_table(nl_table_t *tl, u_int type, const char *fname, FILE *fp)
 {
 	char *buf = NULL;
 	int l = 0;
-	FILE *fp;
 	size_t n;
 
-	fp = fopen(fname, "r");
-	if (fp == NULL) {
+	if (fp == NULL && (fp = fopen(fname, "r")) == NULL) {
 		err(EXIT_FAILURE, "open '%s'", fname);
 	}
 	while (l++, getline(&buf, &n, fp) != -1) {
@@ -908,22 +913,41 @@ npfctl_fill_table(nl_table_t *tl, u_int type, const char *fname)
 }
 
 /*
+ * npfctl_load_table: create an NPF table and fill with contents from a file.
+ */
+nl_table_t *
+npfctl_load_table(const char *tname, int tid, u_int type,
+    const char *fname, FILE *fp)
+{
+	nl_table_t *tl;
+
+	tl = npf_table_create(tname, tid, type);
+	if (tl && fname) {
+		npfctl_fill_table(tl, type, fname, fp);
+	}
+
+	return tl;
+}
+
+/*
  * npfctl_build_table: create an NPF table, add to the configuration and,
  * if required, fill with contents from a file.
  */
 void
-npfctl_build_table(const char *tname, u_int type, const char *fname)
+npfctl_build_table(const char *tname, int tid, u_int type, const char *fname)
 {
 	nl_table_t *tl;
 
-	tl = npf_table_create(tname, npfctl_tid_counter++, type);
-	assert(tl != NULL);
-
-	if (fname) {
-		npfctl_fill_table(tl, type, fname);
-	} else if (type == NPF_TABLE_CONST) {
+	if (type == NPF_TABLE_CONST && !fname) {
 		yyerror("table type 'const' must be loaded from a file");
 	}
+
+	if (tid < 0) {
+		tid = npfctl_tid_counter++;
+	}
+
+	tl = npfctl_load_table(tname, tid, type, fname, NULL);
+	assert(tl != NULL);
 
 	if (npf_table_insert(npf_conf, tl)) {
 		yyerror("table '%s' is already defined", tname);

--- a/src/npfctl/npf_build.c
+++ b/src/npfctl/npf_build.c
@@ -934,7 +934,7 @@ npfctl_load_table(const char *tname, int tid, u_int type,
  * if required, fill with contents from a file.
  */
 void
-npfctl_build_table(const char *tname, int tid, u_int type, const char *fname)
+npfctl_build_table(const char *tname, u_int type, const char *fname)
 {
 	nl_table_t *tl;
 
@@ -942,11 +942,7 @@ npfctl_build_table(const char *tname, int tid, u_int type, const char *fname)
 		yyerror("table type 'const' must be loaded from a file");
 	}
 
-	if (tid < 0) {
-		tid = npfctl_tid_counter++;
-	}
-
-	tl = npfctl_load_table(tname, tid, type, fname, NULL);
+	tl = npfctl_load_table(tname, npfctl_tid_counter++, type, fname, NULL);
 	assert(tl != NULL);
 
 	if (npf_table_insert(npf_conf, tl)) {

--- a/src/npfctl/npf_parse.y
+++ b/src/npfctl/npf_parse.y
@@ -314,7 +314,7 @@ element
 table
 	: TABLE TABLE_ID TYPE table_type table_store
 	{
-		npfctl_build_table($2, -1, $4, $5);
+		npfctl_build_table($2, $4, $5);
 	}
 	;
 

--- a/src/npfctl/npf_parse.y
+++ b/src/npfctl/npf_parse.y
@@ -314,7 +314,7 @@ element
 table
 	: TABLE TABLE_ID TYPE table_type table_store
 	{
-		npfctl_build_table($2, $4, $5);
+		npfctl_build_table($2, -1, $4, $5);
 	}
 	;
 

--- a/src/npfctl/npfctl.8
+++ b/src/npfctl/npfctl.8
@@ -27,7 +27,7 @@
 .\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd December 10, 2017
+.Dd August 26, 2019
 .Dt NPFCTL 8
 .Os
 .Sh NAME
@@ -114,28 +114,50 @@ List all rules in the dynamic ruleset specified by
 Remove all rules from the dynamic ruleset specified by
 .Ar name .
 .\" ---
-.It Ic table Ar tid Ic add Aq Ar addr/mask
+.It Ic table Ar name Ic add Aq Ar addr/mask
 In table
-.Ar tid ,
+.Ar name ,
 add the IP address and optionally netmask, specified by
 .Aq Ar addr/mask .
 Only the tables of type "lpm" support masks.
-.It Ic table Ar tid Ic rem Aq Ar addr/mask
+.It Ic table Ar name Ic rem Aq Ar addr/mask
 In table
-.Ar tid ,
+.Ar name ,
 remove the IP address and optionally netmask, specified by
 .Aq Ar addr/mask .
 Only the tables of type "lpm" support masks.
-.It Ic table Ar tid Ic test Aq Ar addr
+.It Ic table Ar name Ic test Aq Ar addr
 Query the table
-.Ar tid
+.Ar name
 for a specific IP address, specified by
 .Ar addr .
 If no mask is specified, a single host is assumed.
-.It Ic table Ar tid Ic list
+.It Ic table Ar name Ic list
 List all entries in the currently loaded table specified by
-.Ar tid .
+.Ar name .
 This operation is expensive and should be used with caution.
+.It Ic table Ar name Ic replace Oo Fl n Ar newname Oc Oo Fl t Ar type Oc Aq Ar path
+Replace the existing table specified by
+.Ar name
+with a new table built from the file specified by
+.Ar path .
+Optionally, the new table will:
+.Bl -tag -width xxxxxxxxxx -compact -offset 3n
+.It Fl n Ar newname
+be named
+.Ar newname ,
+effectively renaming the table.
+If not specified, the name of the table being replaced will be used.
+.It Fl n Ar type
+be of type
+.Ar type ;
+currently supported types are
+.Cm ipset ,
+.Cm lpm ,
+or
+.Cm const .
+If not specified, the type of the table being replaced will be used.
+.El
 .\" ---
 .It Ic save
 Save the active configuration and a snapshot of the current connections.
@@ -200,6 +222,13 @@ Addition and removal of entries in the table whose ID is "vip":
 .Bd -literal -offset indent
 # npfctl table "vip" add 10.0.0.1
 # npfctl table "vip" rem 182.168.0.0/24
+.Ed
+.Pp
+Replacing the existing table which has ID "svr"
+with a new const table populated from file "/tmp/npf_vps_new",
+and renamed to "vps":
+.Bd -literal -offset indent
+# npfctl table "svr" replace -n "vps" -t const "/tmp/npf_vps_new"
 .Ed
 .\" -----
 .Sh SEE ALSO

--- a/src/npfctl/npfctl.c
+++ b/src/npfctl/npfctl.c
@@ -142,10 +142,14 @@ usage(void)
 	    "\t%s rule \"rule-name\" { list | flush }\n",
 	    progname);
 	fprintf(stderr,
-	    "\t%s table <tid> { add | rem | test } <address/mask>\n",
+	    "\t%s table \"table-name\" { add | rem | test } <address/mask>\n",
 	    progname);
 	fprintf(stderr,
-	    "\t%s table <tid> { list | flush }\n",
+	    "\t%s table \"table-name\" { list | flush }\n",
+	    progname);
+	fprintf(stderr,
+	    "\t%s table \"table-name\" replace [-n \"name\"]"
+	    " [-t <type>] <table-file>\n",
 	    progname);
 	fprintf(stderr,
 	    "\t%s save | load\n",
@@ -275,7 +279,101 @@ npfctl_print_addrmask(int alen, const char *fmt, const npf_addr_t *addr,
 	return buf;
 }
 
-__dead static void
+static int
+npfctl_table_type(const char *typename)
+{
+	int i;
+
+	static const struct tbltype_s {
+		const char *name;
+		u_int type;
+	} tbltypes[] = {
+		{ "ipset",	NPF_TABLE_IPSET	},
+		{ "lpm",	NPF_TABLE_LPM	},
+		{ "const",	NPF_TABLE_CONST	},
+		{ NULL,		0		}
+	};
+
+	for (i = 0; tbltypes[i].name != NULL; i++) {
+		if (strcmp(typename, tbltypes[i].name) == 0) {
+			return tbltypes[i].type;
+		}
+	}
+
+	return 0;
+}
+
+static void
+npfctl_table_replace(int fd, int argc, char **argv)
+{
+	const char *name, *newname, *path, *typename = NULL;
+	int c, tid = -1;
+	FILE *fp;
+	nl_config_t *ncf;
+	nl_table_t *t;
+	u_int type = 0;
+
+	name = newname = argv[0];
+	optind = 2;
+	while ((c = getopt(argc, argv, "n:t:")) != -1) {
+		switch (c) {
+		case 't':
+			typename = optarg;
+			break;
+		case 'n':
+			newname = optarg;
+			break;
+		default:
+			fprintf(stderr,
+			    "Usage: %s table \"table-name\" replace "
+			    "[-n \"name\"] [-t <type>] <table-file>\n",
+			    getprogname());
+			exit(EXIT_FAILURE);
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (typename && (type = npfctl_table_type(typename)) == 0) {
+		errx(EXIT_FAILURE, "unsupported table type '%s'", typename);
+	}
+
+	if (argc != 1) {
+		usage();
+	}
+
+	path = argv[0];
+	if (strcmp(path, "-") == 0) {
+		path = "stdin";
+		fp = stdin;
+	} else if ((fp = fopen(path, "r")) == NULL) {
+		err(EXIT_FAILURE, "open '%s'", path);
+	}
+
+	/* Get existing config to lookup ID of existing table */
+	if ((ncf = npf_config_retrieve(fd)) == NULL) {
+		err(EXIT_FAILURE, "npf_config_retrieve()");
+	}
+	if ((t = npfctl_table_getbyname(ncf, name)) == NULL) {
+		errx(EXIT_FAILURE,
+		    "table '%s' not found in the active configuration", name);
+	}
+	tid = npf_table_getid(t);
+	if (!type) {
+		type = npf_table_gettype(t);
+	}
+	npf_config_destroy(ncf);
+
+	if ((t = npfctl_load_table(newname, tid, type, path, fp)) == NULL) {
+		err(EXIT_FAILURE, "table load failed");
+	}
+
+	if (npf_table_replace(fd, t, NULL)) {
+		err(EXIT_FAILURE, "npf_table_replace(<%s>)", name);
+	}
+}
+
+static void
 npfctl_table(int fd, int argc, char **argv)
 {
 	static const struct tblops_s {
@@ -383,7 +481,6 @@ again:
 		    nct.nct_cmd == NPF_CMD_TABLE_LOOKUP ?
 		    "match" : "success");
 	}
-	exit(EXIT_SUCCESS);
 }
 
 static nl_rule_t *
@@ -431,7 +528,7 @@ npfctl_generate_key(nl_rule_t *rl, void *key)
 	free(meta);
 }
 
-__dead static void
+static void
 npfctl_rule(int fd, int argc, char **argv)
 {
 	static const struct ruleops_s {
@@ -509,7 +606,6 @@ npfctl_rule(int fd, int argc, char **argv)
 	if (action == NPF_CMD_RULE_ADD) {
 		printf("OK %" PRIx64 "\n", rule_id);
 	}
-	exit(EXIT_SUCCESS);
 }
 
 static bool bpfjit = true;
@@ -754,7 +850,11 @@ npfctl(int action, int argc, char **argv)
 			usage();
 		}
 		argv += 2;
-		npfctl_table(fd, argc, argv);
+		if (strcmp(argv[1], "replace") == 0) {
+			npfctl_table_replace(fd, argc, argv);
+		} else {
+			npfctl_table(fd, argc, argv);
+		}
 		break;
 	case NPFCTL_RULE:
 		if ((argc -= 2) < 2) {

--- a/src/npfctl/npfctl.h
+++ b/src/npfctl/npfctl.h
@@ -117,6 +117,7 @@ void		npfctl_print_error(const npf_error_t *);
 char *		npfctl_print_addrmask(int, const char *, const npf_addr_t *,
 		    npf_netmask_t);
 void		npfctl_note_interface(const char *);
+nl_table_t *	npfctl_table_getbyname(nl_config_t *, const char *);
 unsigned	npfctl_table_getid(const char *);
 const char *	npfctl_table_getname(nl_config_t *, unsigned, bool *);
 int		npfctl_protono(const char *);
@@ -196,7 +197,10 @@ void		npfctl_show_init(void);
 int		npfctl_ruleset_show(int, const char *);
 
 nl_rule_t *	npfctl_rule_ref(void);
+nl_table_t *	npfctl_table_ref(void);
 bool		npfctl_debug_addif(const char *);
+
+nl_table_t *	npfctl_load_table(const char *, int, u_int, const char *, FILE *);
 
 void		npfctl_build_alg(const char *);
 void		npfctl_build_rproc(const char *, npfvar_t *);
@@ -209,7 +213,7 @@ void		npfctl_build_natseg(int, int, unsigned, const char *,
 		    const addr_port_t *, const addr_port_t *,
 		    const opt_proto_t *, const filt_opts_t *, unsigned);
 void		npfctl_build_maprset(const char *, int, const char *);
-void		npfctl_build_table(const char *, u_int, const char *);
+void		npfctl_build_table(const char *, int, u_int, const char *);
 
 void		npfctl_setparam(const char *, int);
 

--- a/src/npfctl/npfctl.h
+++ b/src/npfctl/npfctl.h
@@ -213,7 +213,7 @@ void		npfctl_build_natseg(int, int, unsigned, const char *,
 		    const addr_port_t *, const addr_port_t *,
 		    const opt_proto_t *, const filt_opts_t *, unsigned);
 void		npfctl_build_maprset(const char *, int, const char *);
-void		npfctl_build_table(const char *, int, u_int, const char *);
+void		npfctl_build_table(const char *, u_int, const char *);
 
 void		npfctl_setparam(const char *, int);
 


### PR DESCRIPTION
Here's an implementation of a frontend command for the table replacement functionality.

Command syntax is:
`npfctl table <tid> replace [-n <newid>] [-t ipset|lpm|const] <path>`

where `path` is the path to the file containing IPs/networks for the table. It all uses the same `npfctl_build_table()` function from the config parser behind the scenes.

Let me know of any changes you'd like me to make.