### PR TITLE
PPTP ALG: Bug fixes and improvements.

### DIFF
--- a/src/kern/npf_impl.h
+++ b/src/kern/npf_impl.h
@@ -488,15 +488,13 @@ uint64_t	npf_nat_getid(const npf_natpolicy_t *);
 void		npf_nat_freealg(npf_natpolicy_t *, npf_alg_t *);
 
 int		npf_do_nat(npf_cache_t *, npf_conn_t *, const int);
-int		npf_nat_share_policy(npf_cache_t *, npf_conn_t *, npf_nat_t *);
+npf_nat_t *	npf_nat_share_policy(npf_cache_t *, npf_conn_t *, npf_nat_t *);
 void		npf_nat_destroy(npf_conn_t *, npf_nat_t *);
 void		npf_nat_getorig(npf_nat_t *, npf_addr_t **, in_port_t *);
 void		npf_nat_gettrans(npf_nat_t *, npf_addr_t **, in_port_t *);
 void		npf_nat_setalg(npf_nat_t *, npf_alg_t *, uintptr_t);
-void		npf_nat_set_alg_arg(npf_nat_t *, uintptr_t);
-void *		npf_nat_cas_alg_arg(npf_nat_t *, uintptr_t, uintptr_t);
-uintptr_t	npf_nat_get_alg_arg(const npf_nat_t *);
 npf_alg_t *	npf_nat_getalg(const npf_nat_t *);
+uintptr_t	npf_nat_getalgarg(const npf_nat_t *);
 
 void		npf_nat_export(nvlist_t *, npf_nat_t *);
 npf_nat_t *	npf_nat_import(npf_t *, const nvlist_t *, npf_ruleset_t *,

--- a/src/kern/npf_nat.c
+++ b/src/kern/npf_nat.c
@@ -599,7 +599,7 @@ npf_nat_algo(npf_cache_t *npc, const npf_natpolicy_t *np, bool forw)
 /*
  * Associate NAT policy with an existing connection state.
  */
-int
+npf_nat_t *
 npf_nat_share_policy(npf_cache_t *npc, npf_conn_t *con, npf_nat_t *src_nt)
 {
 	npf_natpolicy_t *np = src_nt->nt_natpolicy;
@@ -609,7 +609,7 @@ npf_nat_share_policy(npf_cache_t *npc, npf_conn_t *con, npf_nat_t *src_nt)
 	/* Create a new NAT entry. */
 	nt = npf_nat_create(npc, np, con);
 	if (__predict_false(nt == NULL)) {
-		return ENOMEM;
+		return NULL;
 	}
 	atomic_inc_uint(&np->n_refcnt);
 
@@ -618,9 +618,9 @@ npf_nat_share_policy(npf_cache_t *npc, npf_conn_t *con, npf_nat_t *src_nt)
 	if (__predict_false(ret)) {
 		/* Will release the reference. */
 		npf_nat_destroy(con, nt);
-		return ret;
+		return NULL;
 	}
-	return 0;
+	return nt;
 }
 
 /*
@@ -775,21 +775,9 @@ npf_nat_getalg(const npf_nat_t *nt)
 }
 
 uintptr_t
-npf_nat_get_alg_arg(const npf_nat_t *nt)
+npf_nat_getalgarg(const npf_nat_t *nt)
 {
 	return nt->nt_alg_arg;
-}
-
-void
-npf_nat_set_alg_arg(npf_nat_t *nt, uintptr_t arg)
-{
-	nt->nt_alg_arg = arg;
-}
-
-void *
-npf_nat_cas_alg_arg(npf_nat_t *nt, uintptr_t old_arg, uintptr_t new_arg)
-{
-	return (void *)atomic_cas_64(&nt->nt_alg_arg, old_arg, new_arg);
 }
 
 /*


### PR DESCRIPTION
- pptp_gre_get_state: fix the convoluted logic and a bug.
- Refactor to eliminate the need for pptp_gre_state_t::u64.
- npf_alg_pptp_init: fix the leaks in the error paths.
- pptp_tcp_ctx_alloc: use KM_NOSLEEP when allocating.
- pptp_gre_establish_state: check for failure in the caller.
- pptp_tcp_translate: fix nbuf handling (from m00nbsd via #59).
- pptp_{tcp,gre}_translate: check that there is an ALG associated.
- Move pptp_tcp_ctx_alloc() to pptp_tcp_match().
- Simplify and eliminate pptp_gre_ctx_t.
- Simplify and eliminate npf_nat_cas_alg_arg().
- Eliminate the need for __NPF_CONN_PRIVATE.