### PR TITLE
Decouple PPTP ALG from the NPF core.

### DIFF
--- a/src/kern/npf.h
+++ b/src/kern/npf.h
@@ -142,12 +142,9 @@ int		nbuf_find_tag(nbuf_t *, uint32_t *);
 
 #define	NPC_FMTERR	0x200	/* Format error. */
 
-// #ifdef PPTP_ALG
-#define	NPC_ENHANCED_GRE	0x400	/* Enhanced GRE header */
-#define	NPC_ALG_PPTP_GRE_CTX	0x800	/* PPTP GRE context */
-// #endif
-
 #define	NPC_IP46	(NPC_IP4|NPC_IP6)
+
+struct npf_connkey;
 
 typedef struct {
 	/* NPF context, information flags and the nbuf. */
@@ -180,6 +177,13 @@ typedef struct {
 		struct icmp6_hdr *	icmp6;
 		void *			hdr;
 	} npc_l4;
+
+	/*
+	 * Override the connection key, if not NULL.  This affects the
+	 * behaviour of npf_conn_lookup() and npf_conn_establish().
+	 * Note: npc_ckey is of npf_connkey_t type.
+	 */
+	const void *		npc_ckey;
 } npf_cache_t;
 
 static inline bool

--- a/src/kern/npf_alg_icmp.c
+++ b/src/kern/npf_alg_icmp.c
@@ -203,9 +203,9 @@ npfa_icmp_inspect(npf_cache_t *npc, npf_cache_t *enpc)
 	if (!nbuf_advance(nbuf, npc->npc_hlen, 0)) {
 		return false;
 	}
+	memset(enpc, 0, sizeof(npf_cache_t));
 	enpc->npc_ctx = npc->npc_ctx;
 	enpc->npc_nbuf = nbuf;
-	enpc->npc_info = 0;
 
 	/*
 	 * Inspect the ICMP packet.  The relevant data might be in the

--- a/src/kern/npf_alg_pptp.c
+++ b/src/kern/npf_alg_pptp.c
@@ -59,7 +59,7 @@ static npf_pptp_alg_t		pptp_alg	__cacheline_aligned;
 
 #define	PPTP_OUTGOING_CALL_MIN_LEN	32
 
-#define	PPTP_MAGIC_COOKIE		0X1a2b3c4d
+#define	PPTP_MAGIC_COOKIE		0x1a2b3c4d
 
 /*
  * GRE headers: standard and PPTP ("enhanced").
@@ -72,12 +72,7 @@ static npf_pptp_alg_t		pptp_alg	__cacheline_aligned;
 typedef struct {
 	uint16_t	flags_ver;
 	uint16_t	proto;
-	/* optional fields */
-} __packed gre_hdr_t;
-
-typedef struct {
-	uint16_t	flags_ver;
-	uint16_t	proto;
+	/* enhanced header: */
 	uint16_t	payload_len;
 	uint16_t	call_id;
 	/* optional fields */
@@ -173,51 +168,6 @@ static void		pptp_tcp_ctx_free(pptp_tcp_ctx_t *);
 
 ///////////////////////////////////////////////////////////////////////////
 
-int
-npf_pptp_gre_cache(npf_cache_t *npc, nbuf_t *nbuf, unsigned hlen)
-{
-	gre_hdr_t *gre_hdr;
-	unsigned ver;
-
-	gre_hdr = nbuf_advance(nbuf, hlen, sizeof(gre_hdr_t));
-	if (__predict_false(gre_hdr == NULL)) {
-		return 0;
-	}
-	ver = ntohs(gre_hdr->flags_ver) & GRE_VER_FLD_MASK;
-	if (ver == GRE_ENHANCED_HDR_VER) {
-		npc->npc_l4.hdr = nbuf_ensure_contig(nbuf, sizeof(pptp_gre_hdr_t));
-		return NPC_LAYER4 | NPC_ENHANCED_GRE;
-	}
-	return 0;
-}
-
-void
-npf_pptp_conn_conkey(const npf_cache_t *npc, uint16_t *id, bool forw)
-{
-	KASSERT(npf_iscached(npc, NPC_ENHANCED_GRE));
-
-	if (npf_iscached(npc, NPC_ALG_PPTP_GRE_CTX)) {
-		const pptp_gre_state_t *gre_state = npc->npc_l4.hdr;
-
-		if (forw) {
-			/* PPTP client -> PPTP server. */
-			id[NPF_SRC] = gre_state->call_id[SERVER_CALL_ID];
-			id[NPF_DST] = 0; /* not used */
-		} else {
-			/* PPTP client <- PPTP server */
-			id[NPF_SRC] = 0; /* not used */
-			id[NPF_DST] = gre_state->call_id[CLIENT_CALL_ID];
-		}
-	} else {
-		const pptp_gre_hdr_t *pptp_gre_hdr;
-
-		/* NPC_ALG_PPTP_GRE */
-		pptp_gre_hdr = npc->npc_l4.hdr;
-		id[NPF_SRC] = pptp_gre_hdr->call_id;
-		id[NPF_DST] = 0; /* not used */
-	}
-}
-
 static inline uint16_t
 pptp_call_id_get(const npf_addr_t *ip)
 {
@@ -230,15 +180,61 @@ pptp_call_id_put(const npf_addr_t *ip, uint16_t call_id)
 	npf_portmap_put(pptp_alg.pm, sizeof(uint32_t), ip, call_id);
 }
 
+///////////////////////////////////////////////////////////////////////////
+
+static void
+pptp_gre_prepare_state(const npf_cache_t *npc, npf_nat_t *nt,
+    const pptp_gre_state_t *gre_state, npf_cache_t *gre_npc,
+    npf_connkey_t *ckey)
+{
+	uint16_t gre_id[2];
+	npf_addr_t *o_addr;
+	in_port_t o_port;
+
+	/*
+	 * Create PPTP GRE context cache.  Needed for:
+	 *
+	 * => npf_conn_establish() to pick up a different protocol.
+	 * => npf_nat_share_policy() to obtain the IP addresses.
+	 */
+	memcpy(gre_npc, npc, sizeof(npf_cache_t));
+	gre_npc->npc_proto = IPPROTO_GRE;
+	gre_npc->npc_info = NPC_IP46 | NPC_LAYER4;
+
+	/*
+	 * Setup the IP addresses and call IDs.
+	 *
+	 * PPTP client -> PPTP server (and vice versa, if forw = false).
+	 */
+	npf_nat_getorig(nt, &o_addr, &o_port);
+	gre_npc->npc_ips[NPF_SRC] = o_addr;
+	gre_npc->npc_ips[NPF_DST] = npc->npc_ips[NPF_SRC];
+	gre_id[NPF_SRC] = gre_state->call_id[SERVER_CALL_ID];
+	gre_id[NPF_DST] = 0; /* not used */
+
+	/*
+	 * Additionally, set the custom key for npf_conn_establish().
+	 * We need bypass key construction as this is a custom protocol,
+	 * i.e. "enhanced PPTP" is unknown to npf_conn_conkey().
+	 */
+	npf_connkey_setkey(ckey, IPPROTO_GRE, gre_npc->npc_ips,
+	    gre_id, npc->npc_alen, true);
+	gre_npc->npc_ckey = &ckey;
+}
+
 static int
 pptp_gre_establish_state(npf_cache_t *npc, const int di,
     pptp_gre_state_t *gre_state, npf_nat_t *pptp_tcp_nt)
 {
+	npf_cache_t gre_npc;
+	npf_connkey_t ckey;
 	npf_conn_t *con = NULL;
 	npf_nat_t *nt;
 
+	pptp_gre_prepare_state(npc, pptp_tcp_nt, gre_state, &gre_npc, &ckey);
+
 	/* Establish a state for the GRE connection. */
-	con = npf_conn_establish(npc, di, true);
+	con = npf_conn_establish(&gre_npc, di, true);
 	if (con == NULL)
 		return ENOMEM;
 
@@ -247,12 +243,13 @@ pptp_gre_establish_state(npf_cache_t *npc, const int di,
 	 * same NAT policy as the parent PPTP TCP control connection uses.
 	 * Associate the created NAT entry with the GRE connection.
 	 */
-	nt = npf_nat_share_policy(npc, con, pptp_tcp_nt);
+	nt = npf_nat_share_policy(&gre_npc, con, pptp_tcp_nt);
 	if (nt == NULL) {
 		npf_conn_expire(con);
 		npf_conn_release(con);
 		return ENOMEM;
 	}
+	gre_state->flags |= GRE_STATE_ESTABLISHED;
 
 	/* Associate GRE ALG with the GRE connection. */
 	npf_nat_setalg(nt, pptp_alg.gre, (uintptr_t)(const void *)gre_state);
@@ -260,8 +257,6 @@ pptp_gre_establish_state(npf_cache_t *npc, const int di,
 	/* Make GRE connection state active and passing. */
 	npf_conn_setpass(con, NULL, NULL);
 	npf_conn_release(con);
-
-	gre_state->flags |= GRE_STATE_ESTABLISHED;
 	return 0;
 }
 
@@ -372,11 +367,14 @@ pptp_gre_lookup_state(pptp_tcp_ctx_t *tcp_ctx, unsigned which, uint16_t call_id)
 	for (unsigned i = 0; i < PPTP_MAX_GRE_PER_CLIENT; i++) {
 		pptp_gre_state_t *gre_state = &tcp_ctx->gre_conns[i];
 
-		if ((gre_state->flags & GRE_STATE_USED) != 0 &&
-		    gre_state->call_id[which] == call_id &&
-		    (which == CLIENT_CALL_ID ||
-		        (gre_state->flags & GRE_STATE_SERVER_CALL_ID) != 0))
+		if ((gre_state->flags & GRE_STATE_USED) == 0)
+			continue;
+		if (gre_state->call_id[which] != call_id)
+			continue;
+		if ((gre_state->flags & GRE_STATE_SERVER_CALL_ID) != 0 ||
+		    (which == CLIENT_CALL_ID)) {
 			return gre_state;
+		}
 	}
 	return NULL;
 }
@@ -529,6 +527,7 @@ pptp_tcp_translate(npf_cache_t *npc, npf_nat_t *nt, bool forw)
 		mutex_enter(&tcp_ctx->lock);
 		gre_state = pptp_gre_lookup_state(tcp_ctx,
 		    CLIENT_CALL_ID, pptp_call_reply->peer_call_id);
+
 		if (gre_state == NULL ||
 		    (gre_state->flags & GRE_STATE_SERVER_CALL_ID) != 0) {
 			/*
@@ -537,39 +536,21 @@ pptp_tcp_translate(npf_cache_t *npc, npf_nat_t *nt, bool forw)
 			 */
 			mutex_exit(&tcp_ctx->lock);
 			return false;
-		} else {
-			npf_cache_t gre_npc;
-			npf_addr_t *o_addr;
+		}
 
-			/* Save the server call ID. */
-			gre_state->call_id[SERVER_CALL_ID]= pptp_call_reply->hdr.call_id;
-			gre_state->flags |= GRE_STATE_SERVER_CALL_ID;
+		/* Save the server call ID. */
+		gre_state->call_id[SERVER_CALL_ID]= pptp_call_reply->hdr.call_id;
+		gre_state->flags |= GRE_STATE_SERVER_CALL_ID;
 
-			/*
-			 * Client and server call IDs have been seen, create
-			 * new GRE connection state entry.
-			 */
-
-			/* Create PPTP GRE context cache. */
-			memcpy(&gre_npc, npc, sizeof(npf_cache_t));
-			gre_npc.npc_proto = IPPROTO_GRE;
-			gre_npc.npc_info = NPC_IP46 | NPC_LAYER4 | NPC_ALG_PPTP_GRE_CTX;
-			gre_npc.npc_l4.hdr = (void *)gre_state;
-
-			/* Setup the IP addresses. */
-			npf_nat_getorig(nt, &o_addr, &o_port);
-			gre_npc.npc_ips[NPF_SRC] = o_addr;
-			gre_npc.npc_ips[NPF_DST] = npc->npc_ips[NPF_SRC];
-
-			/*
-			 * Establish the GRE connection state and associate
-			 * the NAT entry.
-			 */
-			if (pptp_gre_establish_state(&gre_npc, PFIL_OUT,
-			    gre_state, nt) != 0) {
-				mutex_exit(&tcp_ctx->lock);
-				return false;
-			}
+		/*
+		 * Client and server call IDs have been seen.  Create a new
+		 * GRE connection state entry and share the NAT entry with
+		 * the TCP state.
+		 */
+		if (pptp_gre_establish_state(npc, PFIL_OUT, gre_state, nt)) {
+			gre_state->flags &= ~GRE_STATE_SERVER_CALL_ID;
+			mutex_exit(&tcp_ctx->lock);
+			return false;
 		}
 		orig_client_call_id = gre_state->orig_client_call_id;
 		mutex_exit(&tcp_ctx->lock);
@@ -664,6 +645,49 @@ pptp_tcp_destroy(npf_t *npf, npf_nat_t *nt, npf_conn_t *con)
 
 ///////////////////////////////////////////////////////////////////////////
 
+
+/*
+ * pptp_gre_inspect: lookup a custom PPTP GRE connection state.
+ */
+static npf_conn_t *
+pptp_gre_inspect(npf_cache_t *npc, int di)
+{
+	nbuf_t *nbuf = npc->npc_nbuf;
+	pptp_gre_hdr_t *gre_hdr;
+	npf_connkey_t ckey;
+	uint16_t gre_id[2];
+	npf_conn_t *con;
+	unsigned ver;
+	bool forw;
+
+	if (npc->npc_proto != IPPROTO_GRE) {
+		return NULL;
+	}
+	gre_hdr = nbuf_advance(nbuf, npc->npc_hlen, sizeof(pptp_gre_hdr_t));
+	if (gre_hdr == NULL) {
+		return NULL;
+	}
+	ver = ntohs(gre_hdr->flags_ver) & GRE_VER_FLD_MASK;
+	if (ver != GRE_ENHANCED_HDR_VER) {
+		return NULL;
+	}
+
+	/*
+	 * Prepare the GRE connection key.
+	 */
+	gre_id[NPF_SRC] = gre_hdr->call_id;
+	gre_id[NPF_DST] = 0; /* not used */
+	npf_connkey_setkey(&ckey, IPPROTO_GRE, npc->npc_ips,
+	    gre_id, npc->npc_alen, true);
+
+	/* Lookup using the custom key. */
+	npc->npc_ckey = &ckey;
+	con = npf_conn_lookup(npc, di, &forw);
+	npc->npc_ckey = NULL;
+
+	return con;
+}
+
 /*
  * pptp_gre_translate: translate the PPTP GRE connection.
  */
@@ -672,23 +696,33 @@ pptp_gre_translate(npf_cache_t *npc, npf_nat_t *nt, bool forw)
 {
 	nbuf_t *nbuf = npc->npc_nbuf;
 	const pptp_gre_state_t *gre_state;
-	pptp_gre_hdr_t *gre;
+	pptp_gre_hdr_t *gre_hdr;
+	unsigned ver;
 
-	if (forw || !npf_iscached(npc, NPC_IP4)) {
-		return false;
-	}
-	if (!npf_iscached(npc, NPC_ENHANCED_GRE) || !npf_nat_getalg(nt)) {
+	if (forw || !npf_iscached(npc, NPC_IP4) || !npf_nat_getalg(nt)) {
 		return false;
 	}
 
+	/*
+	 * Note: since pptp_gre_inspect() cannot pass an arbitrary ALG
+	 * information right now, we need to re-check the header.
+	 */
 	nbuf_reset(nbuf);
-	gre = nbuf_advance(nbuf, npc->npc_hlen, sizeof(pptp_gre_hdr_t));
-	if (gre == NULL)
+	gre_hdr = nbuf_advance(nbuf, npc->npc_hlen, sizeof(pptp_gre_hdr_t));
+	if (gre_hdr == NULL) {
 		return false;
+	}
+	ver = ntohs(gre_hdr->flags_ver) & GRE_VER_FLD_MASK;
+	if (ver != GRE_ENHANCED_HDR_VER) {
+		return false;
+	}
 
 	gre_state = (const void *)npf_nat_getalgarg(nt);
-	KASSERT(gre->call_id == gre_state->call_id[CLIENT_CALL_ID]);
-	gre->call_id = gre_state->orig_client_call_id;
+	KASSERT(gre_hdr->call_id == gre_state->call_id[CLIENT_CALL_ID]);
+	gre_hdr->call_id = gre_state->orig_client_call_id;
+
+	// FIXME: IP checksum?
+
 	return true;
 }
 
@@ -736,7 +770,7 @@ npf_alg_pptp_init(npf_t *npf)
 	static const npfa_funcs_t pptp_gre = {
 		.match		= NULL,
 		.translate	= pptp_gre_translate,
-		.inspect	= NULL,
+		.inspect	= pptp_gre_inspect,
 		.destroy	= pptp_gre_destroy,
 	};
 
@@ -751,7 +785,7 @@ npf_alg_pptp_init(npf_t *npf)
 		return ENOMEM;
 	}
 	pptp_alg.gre = npf_alg_register(npf, "pptp_gre", &pptp_gre);
-	if (pptp_alg.tcp == NULL) {
+	if (pptp_alg.gre == NULL) {
 		npf_alg_pptp_fini(npf);
 		return ENOMEM;
 	}
@@ -761,14 +795,17 @@ npf_alg_pptp_init(npf_t *npf)
 __dso_public int
 npf_alg_pptp_fini(npf_t *npf)
 {
-	if (pptp_alg.pm) {
-		npf_portmap_destroy(pptp_alg.pm);
-	}
 	if (pptp_alg.tcp) {
 		npf_alg_unregister(npf, pptp_alg.tcp);
+		pptp_alg.tcp = NULL;
 	}
 	if (pptp_alg.gre) {
 		npf_alg_unregister(npf, pptp_alg.gre);
+		pptp_alg.gre = NULL;
+	}
+	if (pptp_alg.pm) {
+		npf_portmap_destroy(pptp_alg.pm);
+		pptp_alg.pm = NULL;
 	}
 	return 0;
 }

--- a/src/kern/npf_handler.c
+++ b/src/kern/npf_handler.c
@@ -135,10 +135,10 @@ npfk_packet_handler(npf_t *npf, struct mbuf **mp, ifnet_t *ifp, int di)
 	 * Initialise packet information cache.
 	 * Note: it is enough to clear the info bits.
 	 */
-	npc.npc_ctx = npf;
 	nbuf_init(npf, &nbuf, *mp, ifp);
+	memset(&npc, 0, sizeof(npf_cache_t));
+	npc.npc_ctx = npf;
 	npc.npc_nbuf = &nbuf;
-	npc.npc_info = 0;
 
 	mi.mi_di = di;
 	mi.mi_rid = 0;

--- a/src/kern/npf_impl.h
+++ b/src/kern/npf_impl.h
@@ -514,12 +514,6 @@ npf_conn_t *	npf_alg_conn(npf_cache_t *, int);
 int		npf_alg_export(npf_t *, nvlist_t *);
 void		npf_alg_destroy(npf_t *, npf_alg_t *, npf_nat_t *, npf_conn_t *);
 
-// #ifdef PPTP_ALG
-/* PPTP ALG interface */
-void		npf_pptp_conn_conkey(const npf_cache_t *, uint16_t *, bool);
-int		npf_pptp_gre_cache(npf_cache_t *, nbuf_t *, unsigned);
-// #endif
-
 /* Wrappers for the reclamation mechanism. */
 ebr_t *		npf_ebr_create(void);
 void		npf_ebr_destroy(ebr_t *);

--- a/src/kern/npf_inet.c
+++ b/src/kern/npf_inet.c
@@ -38,7 +38,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf_inet.c,v 1.54 2019/07/23 00:52:01 rmind Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/types.h>
@@ -623,12 +623,6 @@ again:
 		    sizeof(struct icmp6_hdr));
 		l4flags = NPC_LAYER4 | NPC_ICMP;
 		break;
-#ifdef PPTP_ALG
-	case IPPROTO_GRE:
-		/* Cache: layer 4 - GRE. */
-		l4flags = npf_pptp_gre_cache(npc, nbuf, hlen);
-		break;
-#endif
 	default:
 		l4flags = 0;
 		break;

--- a/src/kern/npf_state.c
+++ b/src/kern/npf_state.c
@@ -33,7 +33,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf_state.c,v 1.22 2019/07/23 00:52:01 rmind Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/systm.h>
@@ -115,14 +115,12 @@ npf_state_sysinit(npf_t *npf)
 			.default_val = 60,
 			.min = 0, .max = INT_MAX
 		},
-#ifdef PPTP_ALG
 		{
 			"state.generic.timeout.gre",
 			&params->gre_timeout,
 			.default_val = 24 * 60 * 60,
 			.min = 0, .max = INT_MAX
 		},
-#endif
 	};
 	npf_param_register(npf, param_map, __arraycount(param_map));
 	npf_state_tcp_sysinit(npf);
@@ -161,9 +159,7 @@ npf_state_init(npf_cache_t *npc, npf_state_t *nst)
 		break;
 	case IPPROTO_UDP:
 	case IPPROTO_ICMP:
-#ifdef PPTP_ALG
 	case IPPROTO_GRE:
-#endif
 		/* Generic. */
 		nst->nst_state = npf_generic_fsm[nst->nst_state][NPF_FLOW_FORW];
 		ret = true;
@@ -201,9 +197,7 @@ npf_state_inspect(npf_cache_t *npc, npf_state_t *nst, const bool forw)
 		break;
 	case IPPROTO_UDP:
 	case IPPROTO_ICMP:
-#ifdef PPTP_ALG
 	case IPPROTO_GRE:
-#endif
 		/* Generic. */
 		nst->nst_state = npf_generic_fsm[nst->nst_state][di];
 		ret = true;
@@ -237,12 +231,10 @@ npf_state_etime(npf_t *npf, const npf_state_t *nst, const int proto)
 		params = npf->params[NPF_PARAMS_GENERIC_STATE];
 		timeout = params->timeouts[state];
 		break;
-#ifdef PPTP_ALG
 	case IPPROTO_GRE:
 		params = npf->params[NPF_PARAMS_GENERIC_STATE];
 		timeout = params->gre_timeout;
 		break;
-#endif
 	default:
 		KASSERT(false);
 	}

--- a/src/npftest/libnpftest/npf_nat_test.c
+++ b/src/npftest/libnpftest/npf_nat_test.c
@@ -164,8 +164,8 @@ static bool
 checkresult(bool verbose, unsigned i, struct mbuf *m, ifnet_t *ifp, int error)
 {
 	const struct test_case *t = &test_cases[i];
-	npf_cache_t npc = { .npc_info = 0, .npc_ctx = npf_getkernctx() };
 	const int af = t->af;
+	npf_cache_t npc;
 	nbuf_t nbuf;
 
 	if (verbose) {
@@ -176,7 +176,10 @@ checkresult(bool verbose, unsigned i, struct mbuf *m, ifnet_t *ifp, int error)
 	}
 
 	nbuf_init(npf_getkernctx(), &nbuf, m, ifp);
+	memset(&npc, 0, sizeof(npf_cache_t));
+	npc.npc_ctx = npf_getkernctx();
 	npc.npc_nbuf = &nbuf;
+
 	if (!npf_cache_all(&npc)) {
 		printf("error: could not fetch the packet data");
 		return false;


### PR DESCRIPTION
- Add npf_cache_t::npc_ckey and allow an establishing or lookin up
  the connection using a custom key.
- Add pptp_gre_prepare_state() and amend pptp_gre_establish_state()
  to use connection establishing with a custom key, such that it would
  not require npf_pptp_conn_conkey().
- Add pptp_gre_inspect() with a custom key lookup and eliminate the
  need for npf_pptp_gre_cache() and npf_pptp_conn_conkey(); remove
  the no longer needed NPC_ALG_PPTP_GRE_CTX flag.
- pptp_gre_translate: check the GRE version here and eliminate the
  the need for NPC_ENHANCED_GRE flag.