### PR TITLE
NPF: add support for configuration loading via socket.

### DIFF
--- a/app/conf/npf.Dockerfile
+++ b/app/conf/npf.Dockerfile
@@ -31,6 +31,9 @@ RUN cd thmap/pkg && make rpm && rpm -ihv RPMS/*/*.rpm
 # liblpm
 RUN git clone https://github.com/rmind/liblpm
 RUN cd liblpm/pkg && make rpm && rpm -ihv RPMS/*/*.rpm
+# rhashmap
+RUN git clone https://github.com/rmind/rhashmap
+RUN cd rhashmap/pkg && make rpm && rpm -ihv RPMS/*/*.rpm
 # bpfjit
 RUN git clone https://github.com/rmind/bpfjit
 RUN cd bpfjit && make rpm && rpm -ihv RPMS/*/*.rpm

--- a/app/src/npf_router.h
+++ b/app/src/npf_router.h
@@ -23,6 +23,8 @@ struct worker;
 
 typedef struct route_table route_table_t;
 
+#define	NPF_CONFSOCK_PATH	"/dev/npf"
+
 #define	MAX_IFNET_IDS		(32) // XXX: hardcoded, e.g. worker_t::bitmap
 
 /*
@@ -58,6 +60,7 @@ typedef struct ifnet {
 
 typedef struct npf_router {
 	npf_t *			npf;
+	int			config_sock;
 	struct rte_mempool *	mbuf_pool;
 	unsigned		pktqueue_size;
 	route_table_t *		rtable;

--- a/src/kern/Makefile
+++ b/src/kern/Makefile
@@ -57,9 +57,9 @@ OBJS=		$(shell awk '/^file/ { print $$2 }' files.npf | \
 		    sed 's:\(.*\)net/npf/\(.*\).c:\2.o:g' | \
 		    egrep -v '^(npf_os|npf_ext_|npf_ifaddr|if_npflog|lpm)')
 
-OBJS+=		stand/bpf_filter.o
+OBJS+=		stand/npfkern.o stand/bpf_filter.o
 OBJS+=		stand/murmurhash.o stand/tls_pth.o
-OBJS+=		stand/ebr_wrappers.o stand/misc.o
+OBJS+=		stand/ebr_wrappers.o
 
 #
 # Flags for the library target

--- a/src/kern/npf.c
+++ b/src/kern/npf.c
@@ -33,7 +33,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf.c,v 1.39 2019/08/06 11:40:15 christos Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/types.h>
@@ -116,10 +116,24 @@ npfk_destroy(npf_t *npf)
 	kmem_free(npf, sizeof(npf_t));
 }
 
+
+/*
+ * npfk_load: (re)load the configuration.
+ *
+ * => Will not modify the configuration reference.
+ */
 __dso_public int
-npfk_load(npf_t *npf, void *config_ref, npf_error_t *err)
+npfk_load(npf_t *npf, const void *config_ref, npf_error_t *err)
 {
-	return npfctl_load(npf, 0, config_ref);
+	const nvlist_t *req = (const nvlist_t *)config_ref;
+	nvlist_t *resp;
+	int error;
+
+	resp = nvlist_create(0);
+	error = npfctl_run_op(npf, IOC_NPF_LOAD, req, resp);
+	nvlist_destroy(resp);
+
+	return error;
 }
 
 __dso_public void

--- a/src/kern/npf_alg.c
+++ b/src/kern/npf_alg.c
@@ -333,7 +333,7 @@ npf_alg_destroy(npf_t *npf, npf_alg_t *alg, npf_nat_t *nat, npf_conn_t *con)
  * npf_alg_export: serialise the configuration of ALGs.
  */
 int
-npf_alg_export(npf_t *npf, nvlist_t *npf_dict)
+npf_alg_export(npf_t *npf, nvlist_t *nvl)
 {
 	npf_algset_t *aset = npf->algset;
 
@@ -348,7 +348,7 @@ npf_alg_export(npf_t *npf, nvlist_t *npf_dict)
 		}
 		algdict = nvlist_create(0);
 		nvlist_add_string(algdict, "name", alg->na_name);
-		nvlist_append_nvlist_array(npf_dict, "algs", algdict);
+		nvlist_append_nvlist_array(nvl, "algs", algdict);
 		nvlist_destroy(algdict);
 	}
 	return 0;

--- a/src/kern/npf_conn.h
+++ b/src/kern/npf_conn.h
@@ -148,7 +148,7 @@ void		npf_conn_remove(npf_conndb_t *, npf_conn_t *);
 void		npf_conn_worker(npf_t *);
 int		npf_conn_import(npf_t *, npf_conndb_t *, const nvlist_t *,
 		    npf_ruleset_t *);
-int		npf_conn_find(npf_t *, const nvlist_t *, nvlist_t **);
+int		npf_conn_find(npf_t *, const nvlist_t *, nvlist_t *);
 void		npf_conn_print(npf_conn_t *);
 
 /*

--- a/src/kern/npf_ctl.c
+++ b/src/kern/npf_ctl.c
@@ -36,7 +36,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf_ctl.c,v 1.54 2019/07/23 00:52:01 rmind Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/conf.h>
@@ -47,53 +47,26 @@ __KERNEL_RCSID(0, "$NetBSD: npf_ctl.c,v 1.54 2019/07/23 00:52:01 rmind Exp $");
 #include "npf_impl.h"
 #include "npf_conn.h"
 
-#define	NPF_IOCTL_DATA_LIMIT	(4 * 1024 * 1024)
-
 #define	NPF_ERR_DEBUG(e) \
 	nvlist_add_string((e), "source-file", __FILE__); \
 	nvlist_add_number((e), "source-line", __LINE__);
 
-static int
-npf_nvlist_copyin(npf_t *npf, void *data, nvlist_t **nvl)
-{
-	int error = 0;
-
-	if (npf->mbufops == NULL) {
-		error = nvlist_copyin(data, nvl, NPF_IOCTL_DATA_LIMIT);
-	} else {
-		*nvl = (nvlist_t *)data;
-	}
-	return error;
-}
-
-static int
-npf_nvlist_copyout(npf_t *npf, void *data, nvlist_t *nvl)
-{
-	int error = 0;
-
-	if (npf->mbufops == NULL) {
-		error = nvlist_copyout(data, nvl);
-	}
-	nvlist_destroy(nvl);
-	return error;
-}
-
 static int __noinline
-npf_mk_params(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict, bool set)
+npf_mk_params(npf_t *npf, const nvlist_t *req, nvlist_t *resp, bool set)
 {
 	const nvlist_t *params;
 	int type, error, val;
 	const char *name;
 	void *cookie;
 
-	params = dnvlist_get_nvlist(npf_dict, "params", NULL);
+	params = dnvlist_get_nvlist(req, "params", NULL);
 	if (params == NULL) {
 		return 0;
 	}
 	cookie = NULL;
 	while ((name = nvlist_next(params, &type, &cookie)) != NULL) {
 		if (type != NV_TYPE_NUMBER) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			return EINVAL;
 		}
 		val = (int)nvlist_get_number(params, name);
@@ -110,11 +83,11 @@ npf_mk_params(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict, bool set)
 			continue;
 		}
 		if (error == ENOENT) {
-			nvlist_add_stringf(errdict, "error-msg",
+			nvlist_add_stringf(resp, "error-msg",
 			    "invalid parameter `%s`", name);
 		}
 		if (error == EINVAL) {
-			nvlist_add_stringf(errdict, "error-msg",
+			nvlist_add_stringf(resp, "error-msg",
 			    "invalid parameter `%s` value %d", name, val);
 		}
 		return error;
@@ -123,33 +96,33 @@ npf_mk_params(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict, bool set)
 }
 
 static int __noinline
-npf_mk_table_entries(npf_table_t *t, const nvlist_t *table, nvlist_t *errdict)
+npf_mk_table_entries(npf_table_t *t, const nvlist_t *req, nvlist_t *resp)
 {
 	const nvlist_t * const *entries;
 	size_t nitems;
 	int error = 0;
 
-	if (!nvlist_exists_nvlist_array(table, "entries")) {
+	if (!nvlist_exists_nvlist_array(req, "entries")) {
 		return 0;
 	}
-	entries = nvlist_get_nvlist_array(table, "entries", &nitems);
+	entries = nvlist_get_nvlist_array(req, "entries", &nitems);
 	for (unsigned i = 0; i < nitems; i++) {
 		const nvlist_t *entry = entries[i];
 		const npf_addr_t *addr;
 		npf_netmask_t mask;
 		size_t alen;
 
-		/* Get address and mask.  Add a table entry. */
+		/* Get address and mask; add a table entry. */
 		addr = dnvlist_get_binary(entry, "addr", &alen, NULL, 0);
 		mask = dnvlist_get_number(entry, "mask", NPF_NO_NETMASK);
 		if (addr == NULL || alen == 0) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			error = EINVAL;
 			break;
 		}
 		error = npf_table_insert(t, alen, addr, mask);
 		if (error) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			break;
 		}
 	}
@@ -160,7 +133,7 @@ npf_mk_table_entries(npf_table_t *t, const nvlist_t *table, nvlist_t *errdict)
  * npf_mk_table: create a table from provided nvlist.
  */
 static int __noinline
-npf_mk_table(npf_t *npf, const nvlist_t *tbl_dict, nvlist_t *errdict,
+npf_mk_table(npf_t *npf, const nvlist_t *req, nvlist_t *resp,
     npf_tableset_t *tblset, npf_table_t **tblp, bool replacing)
 {
 	npf_table_t *t;
@@ -174,36 +147,36 @@ npf_mk_table(npf_t *npf, const nvlist_t *tbl_dict, nvlist_t *errdict,
 	KASSERT(tblp != NULL);
 
 	/* Table name, ID and type.  Validate them. */
-	name = dnvlist_get_string(tbl_dict, "name", NULL);
+	name = dnvlist_get_string(req, "name", NULL);
 	if (!name) {
-		NPF_ERR_DEBUG(errdict);
+		NPF_ERR_DEBUG(resp);
 		error = EINVAL;
 		goto out;
 	}
-	tid = dnvlist_get_number(tbl_dict, "id", UINT64_MAX);
-	type = dnvlist_get_number(tbl_dict, "type", UINT64_MAX);
+	tid = dnvlist_get_number(req, "id", UINT64_MAX);
+	type = dnvlist_get_number(req, "type", UINT64_MAX);
 	error = npf_table_check(tblset, name, tid, type, replacing);
 	if (error) {
-		NPF_ERR_DEBUG(errdict);
+		NPF_ERR_DEBUG(resp);
 		goto out;
 	}
 
 	/* Get the entries or binary data. */
-	blob = dnvlist_get_binary(tbl_dict, "data", &size, NULL, 0);
+	blob = dnvlist_get_binary(req, "data", &size, NULL, 0);
 	if (type == NPF_TABLE_CONST && (blob == NULL || size == 0)) {
-		NPF_ERR_DEBUG(errdict);
+		NPF_ERR_DEBUG(resp);
 		error = EINVAL;
 		goto out;
 	}
 
 	t = npf_table_create(name, (unsigned)tid, type, blob, size);
 	if (t == NULL) {
-		NPF_ERR_DEBUG(errdict);
+		NPF_ERR_DEBUG(resp);
 		error = ENOMEM;
 		goto out;
 	}
 
-	if ((error = npf_mk_table_entries(t, tbl_dict, errdict)) != 0) {
+	if ((error = npf_mk_table_entries(t, req, resp)) != 0) {
 		npf_table_destroy(t);
 		goto out;
 	}
@@ -214,18 +187,17 @@ out:
 }
 
 static int __noinline
-npf_mk_tables(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
-    npf_config_t *nc)
+npf_mk_tables(npf_t *npf, const nvlist_t *req, nvlist_t *resp, npf_config_t *nc)
 {
 	const nvlist_t * const *tables;
 	npf_tableset_t *tblset;
 	size_t nitems;
 	int error = 0;
 
-	if (nvlist_exists_nvlist_array(npf_dict, "tables")) {
-		tables = nvlist_get_nvlist_array(npf_dict, "tables", &nitems);
+	if (nvlist_exists_nvlist_array(req, "tables")) {
+		tables = nvlist_get_nvlist_array(req, "tables", &nitems);
 		if (nitems > NPF_MAX_TABLES) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			return E2BIG;
 		}
 	} else {
@@ -237,7 +209,7 @@ npf_mk_tables(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 		const nvlist_t *table = tables[i];
 		npf_table_t *t;
 
-		error = npf_mk_table(npf, table, errdict, tblset, &t, 0);
+		error = npf_mk_table(npf, table, resp, tblset, &t, 0);
 		if (error) {
 			break;
 		}
@@ -250,19 +222,19 @@ npf_mk_tables(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 }
 
 static npf_rproc_t *
-npf_mk_singlerproc(npf_t *npf, const nvlist_t *rproc, nvlist_t *errdict)
+npf_mk_singlerproc(npf_t *npf, const nvlist_t *rproc, nvlist_t *resp)
 {
 	const nvlist_t * const *extcalls;
 	size_t nitems;
 	npf_rproc_t *rp;
 
 	if (!nvlist_exists_nvlist_array(rproc, "extcalls")) {
-		NPF_ERR_DEBUG(errdict);
+		NPF_ERR_DEBUG(resp);
 		return NULL;
 	}
 	rp = npf_rproc_create(rproc);
 	if (rp == NULL) {
-		NPF_ERR_DEBUG(errdict);
+		NPF_ERR_DEBUG(resp);
 		return NULL;
 	}
 	extcalls = nvlist_get_nvlist_array(rproc, "extcalls", &nitems);
@@ -272,7 +244,7 @@ npf_mk_singlerproc(npf_t *npf, const nvlist_t *rproc, nvlist_t *errdict)
 
 		name = dnvlist_get_string(extcall, "name", NULL);
 		if (!name || npf_ext_construct(npf, name, rp, extcall)) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			npf_rproc_release(rp);
 			rp = NULL;
 			break;
@@ -282,18 +254,17 @@ npf_mk_singlerproc(npf_t *npf, const nvlist_t *rproc, nvlist_t *errdict)
 }
 
 static int __noinline
-npf_mk_rprocs(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
-    npf_config_t *nc)
+npf_mk_rprocs(npf_t *npf, const nvlist_t *req, nvlist_t *resp, npf_config_t *nc)
 {
 	const nvlist_t * const *rprocs;
 	npf_rprocset_t *rpset;
 	size_t nitems;
 	int error = 0;
 
-	if (nvlist_exists_nvlist_array(npf_dict, "rprocs")) {
-		rprocs = nvlist_get_nvlist_array(npf_dict, "rprocs", &nitems);
+	if (nvlist_exists_nvlist_array(req, "rprocs")) {
+		rprocs = nvlist_get_nvlist_array(req, "rprocs", &nitems);
 		if (nitems > NPF_MAX_RPROCS) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			return E2BIG;
 		}
 	} else {
@@ -305,7 +276,7 @@ npf_mk_rprocs(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 		const nvlist_t *rproc = rprocs[i];
 		npf_rproc_t *rp;
 
-		if ((rp = npf_mk_singlerproc(npf, rproc, errdict)) == NULL) {
+		if ((rp = npf_mk_singlerproc(npf, rproc, resp)) == NULL) {
 			error = EINVAL;
 			break;
 		}
@@ -316,13 +287,13 @@ npf_mk_rprocs(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 }
 
 static int __noinline
-npf_mk_algs(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict)
+npf_mk_algs(npf_t *npf, const nvlist_t *req, nvlist_t *resp)
 {
 	const nvlist_t * const *algs;
 	size_t nitems;
 
-	if (nvlist_exists_nvlist_array(npf_dict, "algs")) {
-		algs = nvlist_get_nvlist_array(npf_dict, "algs", &nitems);
+	if (nvlist_exists_nvlist_array(req, "algs")) {
+		algs = nvlist_get_nvlist_array(req, "algs", &nitems);
 	} else {
 		algs = NULL;
 		nitems = 0;
@@ -333,11 +304,11 @@ npf_mk_algs(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict)
 
 		name = dnvlist_get_string(alg, "name", NULL);
 		if (!name) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			return EINVAL;
 		}
 		if (!npf_alg_construct(npf, name)) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			return EINVAL;
 		}
 	}
@@ -345,8 +316,8 @@ npf_mk_algs(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict)
 }
 
 static int __noinline
-npf_mk_singlerule(npf_t *npf, const nvlist_t *rule, npf_rprocset_t *rpset,
-    npf_rule_t **rlret, nvlist_t *errdict)
+npf_mk_singlerule(npf_t *npf, const nvlist_t *req, nvlist_t *resp,
+    npf_rprocset_t *rpset, npf_rule_t **rlret)
 {
 	npf_rule_t *rl;
 	const char *rname;
@@ -354,22 +325,22 @@ npf_mk_singlerule(npf_t *npf, const nvlist_t *rule, npf_rprocset_t *rpset,
 	size_t clen;
 	int error = 0;
 
-	if ((rl = npf_rule_alloc(npf, rule)) == NULL) {
-		NPF_ERR_DEBUG(errdict);
+	if ((rl = npf_rule_alloc(npf, req)) == NULL) {
+		NPF_ERR_DEBUG(resp);
 		return EINVAL;
 	}
 
 	/* Assign the rule procedure, if any. */
-	if ((rname = dnvlist_get_string(rule, "rproc", NULL)) != NULL) {
+	if ((rname = dnvlist_get_string(req, "rproc", NULL)) != NULL) {
 		npf_rproc_t *rp;
 
 		if (rpset == NULL) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			error = EINVAL;
 			goto err;
 		}
 		if ((rp = npf_rprocset_lookup(rpset, rname)) == NULL) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			error = EINVAL;
 			goto err;
 		}
@@ -377,24 +348,24 @@ npf_mk_singlerule(npf_t *npf, const nvlist_t *rule, npf_rprocset_t *rpset,
 	}
 
 	/* Filter byte-code (binary data). */
-	code = dnvlist_get_binary(rule, "code", &clen, NULL, 0);
+	code = dnvlist_get_binary(req, "code", &clen, NULL, 0);
 	if (code) {
 		void *bc;
 		int type;
 
-		type = dnvlist_get_number(rule, "code-type", UINT64_MAX);
+		type = dnvlist_get_number(req, "code-type", UINT64_MAX);
 		if (type != NPF_CODE_BPF) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			error = ENOTSUP;
 			goto err;
 		}
 		if (clen == 0) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			error = EINVAL;
 			goto err;
 		}
 		if (!npf_bpf_validate(code, clen)) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			error = EINVAL;
 			goto err;
 		}
@@ -406,24 +377,23 @@ npf_mk_singlerule(npf_t *npf, const nvlist_t *rule, npf_rprocset_t *rpset,
 	*rlret = rl;
 	return 0;
 err:
-	nvlist_add_number(errdict, "id", dnvlist_get_number(rule, "prio", 0));
+	nvlist_add_number(resp, "id", dnvlist_get_number(req, "prio", 0));
 	npf_rule_free(rl);
 	return error;
 }
 
 static int __noinline
-npf_mk_rules(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
-    npf_config_t *nc)
+npf_mk_rules(npf_t *npf, const nvlist_t *req, nvlist_t *resp, npf_config_t *nc)
 {
 	const nvlist_t * const *rules;
 	npf_ruleset_t *rlset;
 	size_t nitems;
 	int error = 0;
 
-	if (nvlist_exists_nvlist_array(npf_dict, "rules")) {
-		rules = nvlist_get_nvlist_array(npf_dict, "rules", &nitems);
+	if (nvlist_exists_nvlist_array(req, "rules")) {
+		rules = nvlist_get_nvlist_array(req, "rules", &nitems);
 		if (nitems > NPF_MAX_RULES) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			return E2BIG;
 		}
 	} else {
@@ -436,14 +406,13 @@ npf_mk_rules(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 		npf_rule_t *rl = NULL;
 		const char *name;
 
-		error = npf_mk_singlerule(npf, rule, nc->rule_procs, &rl,
-		    errdict);
+		error = npf_mk_singlerule(npf, rule, resp, nc->rule_procs, &rl);
 		if (error) {
 			break;
 		}
 		name = dnvlist_get_string(rule, "name", NULL);
 		if (name && npf_ruleset_lookup(rlset, name)) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			npf_rule_free(rl);
 			error = EEXIST;
 			break;
@@ -455,8 +424,8 @@ npf_mk_rules(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 }
 
 static int __noinline
-npf_mk_singlenat(npf_t *npf, const nvlist_t *nat, npf_ruleset_t *ntset,
-    npf_tableset_t *tblset, nvlist_t *errdict, npf_rule_t **rlp)
+npf_mk_singlenat(npf_t *npf, const nvlist_t *nat, nvlist_t *resp,
+    npf_ruleset_t *ntset, npf_tableset_t *tblset, npf_rule_t **rlp)
 {
 	npf_rule_t *rl = NULL;
 	npf_natpolicy_t *np;
@@ -466,7 +435,7 @@ npf_mk_singlenat(npf_t *npf, const nvlist_t *nat, npf_ruleset_t *ntset,
 	 * NAT rules are standard rules, plus the translation policy.
 	 * We first construct the rule structure.
 	 */
-	error = npf_mk_singlerule(npf, nat, NULL, &rl, errdict);
+	error = npf_mk_singlerule(npf, nat, resp, NULL, &rl);
 	if (error) {
 		return error;
 	}
@@ -483,7 +452,7 @@ npf_mk_singlenat(npf_t *npf, const nvlist_t *nat, npf_ruleset_t *ntset,
 		unsigned tid = nvlist_get_number(nat, "nat-table-id");
 
 		if (!npf_tableset_getbyid(tblset, tid)) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			error = EINVAL;
 			goto out;
 		}
@@ -492,7 +461,7 @@ npf_mk_singlenat(npf_t *npf, const nvlist_t *nat, npf_ruleset_t *ntset,
 	/* Allocate a new NAT policy and assign it to the rule. */
 	np = npf_nat_newpolicy(npf, nat, ntset);
 	if (np == NULL) {
-		NPF_ERR_DEBUG(errdict);
+		NPF_ERR_DEBUG(resp);
 		error = ENOMEM;
 		goto out;
 	}
@@ -505,8 +474,7 @@ out:
 }
 
 static int __noinline
-npf_mk_natlist(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
-    npf_config_t *nc)
+npf_mk_natlist(npf_t *npf, const nvlist_t *req, nvlist_t *resp, npf_config_t *nc)
 {
 	const nvlist_t * const *nat_rules;
 	npf_ruleset_t *ntset;
@@ -516,10 +484,10 @@ npf_mk_natlist(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 	/*
 	 * NAT policies must be an array, but enforce a limit.
 	 */
-	if (nvlist_exists_nvlist_array(npf_dict, "nat")) {
-		nat_rules = nvlist_get_nvlist_array(npf_dict, "nat", &nitems);
+	if (nvlist_exists_nvlist_array(req, "nat")) {
+		nat_rules = nvlist_get_nvlist_array(req, "nat", &nitems);
 		if (nitems > NPF_MAX_RULES) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			return E2BIG;
 		}
 	} else {
@@ -531,8 +499,8 @@ npf_mk_natlist(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 		const nvlist_t *nat = nat_rules[i];
 		npf_rule_t *rl = NULL;
 
-		error = npf_mk_singlenat(npf, nat, ntset, nc->tableset,
-		    errdict, &rl);
+		error = npf_mk_singlenat(npf, nat, resp, ntset,
+		    nc->tableset, &rl);
 		if (error) {
 			break;
 		}
@@ -546,7 +514,7 @@ npf_mk_natlist(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
  * npf_mk_connlist: import a list of connections and load them.
  */
 static int __noinline
-npf_mk_connlist(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
+npf_mk_connlist(npf_t *npf, const nvlist_t *req, nvlist_t *resp,
     npf_config_t *nc, npf_conndb_t **conndb)
 {
 	const nvlist_t * const *conns;
@@ -554,19 +522,19 @@ npf_mk_connlist(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 	size_t nitems;
 	int error = 0;
 
-	if (!nvlist_exists_nvlist_array(npf_dict, "conn-list")) {
+	if (!nvlist_exists_nvlist_array(req, "conn-list")) {
 		*conndb = NULL;
 		return 0;
 	}
 	cd = npf_conndb_create();
-	conns = nvlist_get_nvlist_array(npf_dict, "conn-list", &nitems);
+	conns = nvlist_get_nvlist_array(req, "conn-list", &nitems);
 	for (unsigned i = 0; i < nitems; i++) {
 		const nvlist_t *conn = conns[i];
 
 		/* Construct and insert the connection. */
 		error = npf_conn_import(npf, cd, conn, nc->nat_ruleset);
 		if (error) {
-			NPF_ERR_DEBUG(errdict);
+			NPF_ERR_DEBUG(resp);
 			break;
 		}
 	}
@@ -580,159 +548,121 @@ npf_mk_connlist(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict,
 }
 
 /*
- * npfctl_load_nvlist: store passed data i.e. the update settings, create
- * the passed tables, rules, etc and atomically activate all them.
+ * npfctl_load: store passed data i.e. the update settings, create the
+ * passed rules, tables, etc and atomically activate them all.
  */
 static int
-npfctl_load_nvlist(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict)
+npfctl_load(npf_t *npf, const nvlist_t *req, nvlist_t *resp)
 {
 	npf_config_t *nc;
 	npf_conndb_t *conndb = NULL;
-	uint64_t ver;
 	bool flush;
 	int error;
 
 	nc = npf_config_create();
-	ver = dnvlist_get_number(npf_dict, "version", UINT64_MAX);
-	if (ver != NPF_VERSION) {
-		error = EPROGMISMATCH;
-		goto fail;
-	}
-	error = npf_mk_params(npf, npf_dict, errdict, false /* validate */);
+	error = npf_mk_params(npf, req, resp, false /* validate */);
 	if (error) {
 		goto fail;
 	}
-	error = npf_mk_algs(npf, npf_dict, errdict);
+	error = npf_mk_algs(npf, req, resp);
 	if (error) {
 		goto fail;
 	}
-	error = npf_mk_tables(npf, npf_dict, errdict, nc);
+	error = npf_mk_tables(npf, req, resp, nc);
 	if (error) {
 		goto fail;
 	}
-	error = npf_mk_rprocs(npf, npf_dict, errdict, nc);
+	error = npf_mk_rprocs(npf, req, resp, nc);
 	if (error) {
 		goto fail;
 	}
-	error = npf_mk_natlist(npf, npf_dict, errdict, nc);
+	error = npf_mk_natlist(npf, req, resp, nc);
 	if (error) {
 		goto fail;
 	}
-	error = npf_mk_rules(npf, npf_dict, errdict, nc);
+	error = npf_mk_rules(npf, req, resp, nc);
 	if (error) {
 		goto fail;
 	}
-	error = npf_mk_connlist(npf, npf_dict, errdict, nc, &conndb);
+	error = npf_mk_connlist(npf, req, resp, nc, &conndb);
 	if (error) {
 		goto fail;
 	}
 
-	flush = dnvlist_get_bool(npf_dict, "flush", false);
+	flush = dnvlist_get_bool(req, "flush", false);
 	nc->default_pass = flush;
 
 	/*
 	 * Finally - perform the load.
 	 */
 	npf_config_load(npf, nc, conndb, flush);
-	npf_mk_params(npf, npf_dict, errdict, true /* set the params */);
+	npf_mk_params(npf, req, resp, true /* set the params */);
+	return 0;
 
-	/* Done.  Since data is consumed now, we shall not destroy it. */
-	nc = NULL;
 fail:
-	if (nc) {
-		npf_config_destroy(nc);
-	}
-	nvlist_destroy(npf_dict);
+	npf_config_destroy(nc);
 	return error;
 }
 
-int
-npfctl_load(npf_t *npf, u_long cmd, void *data)
-{
-	nvlist_t *request, *response;
-	int error;
-
-	/*
-	 * Retrieve the configuration and check the version.
-	 * Construct a response with error reporting.
-	 */
-	error = npf_nvlist_copyin(npf, data, &request);
-	if (error) {
-		return error;
-	}
-	response = nvlist_create(0);
-	error = npfctl_load_nvlist(npf, request, response);
-	nvlist_add_number(response, "errno", error);
-	return npf_nvlist_copyout(npf, data, response);
-}
-
 /*
- * npfctl_save: export the config dictionary as it was submitted,
- * including the current snapshot of the connections.  Additionally,
- * indicate whether the ruleset is currently active.
+ * npfctl_save: export the active configuration, including the current
+ * snapshot of the connections.  Additionally, set the version and indicate
+ * whether the ruleset is currently active.
  */
-int
-npfctl_save(npf_t *npf, u_long cmd, void *data)
+static int
+npfctl_save(npf_t *npf, const nvlist_t *req, nvlist_t *resp)
 {
 	npf_config_t *nc;
-	nvlist_t *npf_dict;
 	int error;
 
-	npf_dict = nvlist_create(0);
-	nvlist_add_number(npf_dict, "version", NPF_VERSION);
-
 	/*
-	 * Serialise the whole NPF config, including connections.
+	 * Serialize the whole NPF configuration, including connections.
 	 */
+	nvlist_add_number(resp, "version", NPF_VERSION);
 	nc = npf_config_enter(npf);
-	error = npf_conndb_export(npf, npf_dict);
+	error = npf_conndb_export(npf, resp);
 	if (error) {
 		goto out;
 	}
-	error = npf_ruleset_export(npf, nc->ruleset, "rules", npf_dict);
+	error = npf_ruleset_export(npf, nc->ruleset, "rules", resp);
 	if (error) {
 		goto out;
 	}
-	error = npf_ruleset_export(npf, nc->nat_ruleset, "nat", npf_dict);
+	error = npf_ruleset_export(npf, nc->nat_ruleset, "nat", resp);
 	if (error) {
 		goto out;
 	}
-	error = npf_tableset_export(npf, nc->tableset, npf_dict);
+	error = npf_tableset_export(npf, nc->tableset, resp);
 	if (error) {
 		goto out;
 	}
-	error = npf_rprocset_export(nc->rule_procs, npf_dict);
+	error = npf_rprocset_export(nc->rule_procs, resp);
 	if (error) {
 		goto out;
 	}
-	error = npf_alg_export(npf, npf_dict);
+	error = npf_alg_export(npf, resp);
 	if (error) {
 		goto out;
 	}
-	nvlist_add_bool(npf_dict, "active", npf_active_p());
-	error = npf_nvlist_copyout(npf, data, npf_dict);
-	npf_dict = NULL;
+	nvlist_add_bool(resp, "active", npf_active_p());
 out:
 	npf_config_exit(npf);
-	if (npf_dict) {
-		nvlist_destroy(npf_dict);
-	}
 	return error;
 }
 
 /*
- * npfctl_table_replace_nvlist: atomically replace a table's contents
- * with the passed table data.
+ * npfctl_table_replace: atomically replace a table's contents with
+ * the passed table data.
  */
 static int __noinline
-npfctl_table_replace_nvlist(npf_t *npf, nvlist_t *npf_dict, nvlist_t *errdict)
+npfctl_table_replace(npf_t *npf, const nvlist_t *req, nvlist_t *resp)
 {
 	npf_table_t *tbl, *gc_tbl = NULL;
 	npf_config_t *nc;
 	int error = 0;
 
 	nc = npf_config_enter(npf);
-	error = npf_mk_table(npf, npf_dict, errdict, nc->tableset, &tbl, true);
+	error = npf_mk_table(npf, req, resp, nc->tableset, &tbl, true);
 	if (error) {
 		goto err;
 	}
@@ -751,58 +681,12 @@ err:
 	return error;
 }
 
-int
-npfctl_table_replace(npf_t *npf, u_long cmd, void *data)
-{
-	nvlist_t *request, *response;
-	int error;
-
-	/*
-	 * Retrieve the configuration and check the version.
-	 * Construct a response with error reporting.
-	 */
-	error = npf_nvlist_copyin(npf, data, &request);
-	if (error) {
-		return error;
-	}
-	response = nvlist_create(0);
-	error = npfctl_table_replace_nvlist(npf, request, response);
-	nvlist_add_number(response, "errno", error);
-	error = npf_nvlist_copyout(npf, data, response);
-	nvlist_destroy(request);
-	return error;
-}
-
-/*
- * npfctl_conn_lookup: lookup a connection in the list of connections
- */
-int
-npfctl_conn_lookup(npf_t *npf, u_long cmd, void *data)
-{
-	nvlist_t *conn_data, *conn_result;
-	int error;
-
-	error = npf_nvlist_copyin(npf, data, &conn_data);
-	if (error) {
-		return error;
-	}
-	error = npf_conn_find(npf, conn_data, &conn_result);
-	if (error) {
-		goto out;
-	}
-	error = npf_nvlist_copyout(npf, data, conn_result);
-out:
-	nvlist_destroy(conn_data);
-	return error;
-}
-
 /*
  * npfctl_rule: add or remove dynamic rules in the specified ruleset.
  */
-int
-npfctl_rule(npf_t *npf, u_long cmd, void *data)
+static int
+npfctl_rule(npf_t *npf, const nvlist_t *req, nvlist_t *resp)
 {
-	nvlist_t *npf_rule, *retdict = NULL;
 	npf_ruleset_t *rlset;
 	npf_rule_t *rl = NULL;
 	const char *ruleset_name;
@@ -811,13 +695,9 @@ npfctl_rule(npf_t *npf, u_long cmd, void *data)
 	int error = 0;
 	bool natset;
 
-	error = npf_nvlist_copyin(npf, data, &npf_rule);
-	if (error) {
-		return error;
-	}
-	rcmd = dnvlist_get_number(npf_rule, "command", 0);
-	natset = dnvlist_get_bool(npf_rule, "nat-ruleset", false);
-	ruleset_name = dnvlist_get_string(npf_rule, "ruleset-name", NULL);
+	rcmd = dnvlist_get_number(req, "command", 0);
+	natset = dnvlist_get_bool(req, "nat-ruleset", false);
+	ruleset_name = dnvlist_get_string(req, "ruleset-name", NULL);
 	if (!ruleset_name) {
 		error = EINVAL;
 		goto out;
@@ -827,34 +707,31 @@ npfctl_rule(npf_t *npf, u_long cmd, void *data)
 	rlset = natset ? nc->nat_ruleset : nc->ruleset;
 	switch (rcmd) {
 	case NPF_CMD_RULE_ADD: {
-		retdict = nvlist_create(0);
 		if (natset) {
 			/*
 			 * Translation rule.
 			 */
-			error = npf_mk_singlenat(npf, npf_rule, rlset,
-			    nc->tableset, retdict, &rl);
+			error = npf_mk_singlenat(npf, req, resp, rlset,
+			    nc->tableset, &rl);
 		} else {
 			/*
 			 * Standard rule.
 			 */
-			error = npf_mk_singlerule(npf, npf_rule, NULL,
-			    &rl, retdict);
+			error = npf_mk_singlerule(npf, req, resp, NULL, &rl);
 		}
 		if (error) {
-			npf_config_exit(npf);
 			goto out;
 		}
 		if ((error = npf_ruleset_add(rlset, ruleset_name, rl)) == 0) {
 			/* Success. */
 			uint64_t id = npf_rule_getid(rl);
-			nvlist_add_number(retdict, "id", id);
+			nvlist_add_number(resp, "id", id);
 			rl = NULL;
 		}
 		break;
 	}
 	case NPF_CMD_RULE_REMOVE: {
-		uint64_t id = dnvlist_get_number(npf_rule, "id", UINT64_MAX);
+		uint64_t id = dnvlist_get_number(req, "id", UINT64_MAX);
 		error = npf_ruleset_remove(rlset, ruleset_name, id);
 		break;
 	}
@@ -862,7 +739,7 @@ npfctl_rule(npf_t *npf, u_long cmd, void *data)
 		const void *key;
 		size_t len;
 
-		key = dnvlist_get_binary(npf_rule, "key", &len, NULL, 0);
+		key = dnvlist_get_binary(req, "key", &len, NULL, 0);
 		if (len == 0 || len > NPF_RULE_MAXKEYLEN) {
 			error = EINVAL;
 			break;
@@ -871,10 +748,7 @@ npfctl_rule(npf_t *npf, u_long cmd, void *data)
 		break;
 	}
 	case NPF_CMD_RULE_LIST: {
-		retdict = npf_ruleset_list(npf, rlset, ruleset_name);
-		if (!retdict) {
-			error = ESRCH;
-		}
+		error = npf_ruleset_list(npf, rlset, ruleset_name, resp);
 		break;
 	}
 	case NPF_CMD_RULE_FLUSH: {
@@ -891,17 +765,13 @@ npfctl_rule(npf_t *npf, u_long cmd, void *data)
 		npf_config_sync(npf);
 		npf_ruleset_gc(rlset);
 	}
+out:
 	npf_config_exit(npf);
 
 	if (rl) {
 		KASSERT(error);
 		npf_rule_free(rl);
 	}
-out:
-	if (retdict && npf_nvlist_copyout(npf, data, retdict) != 0) {
-		error = EFAULT; // copyout failure
-	}
-	nvlist_destroy(npf_rule);
 	return error;
 }
 
@@ -957,5 +827,45 @@ npfctl_table(npf_t *npf, void *data)
 	npf_table_gc(npf, t);
 	npf_config_exit(npf);
 
+	return error;
+}
+
+/*
+ * npfctl_run_op: run a particular NPF operation with a given the request.
+ *
+ * => Checks the ABI version.
+ * => Sets the error number for the response.
+ */
+int
+npfctl_run_op(npf_t *npf, unsigned op, const nvlist_t *req, nvlist_t *resp)
+{
+	uint64_t ver;
+	int error;
+
+	ver = dnvlist_get_number(req, "version", UINT64_MAX);
+	if (__predict_false(ver != NPF_VERSION)) {
+		return EPROGMISMATCH;
+	}
+	switch (op) {
+	case IOC_NPF_LOAD:
+		error = npfctl_load(npf, req, resp);
+		break;
+	case IOC_NPF_SAVE:
+		error = npfctl_save(npf, req, resp);
+		break;
+	case IOC_NPF_RULE:
+		error = npfctl_rule(npf, req, resp);
+		break;
+	case IOC_NPF_CONN_LOOKUP:
+		error = npf_conn_find(npf, req, resp);
+		break;
+	case IOC_NPF_TABLE_REPLACE:
+		error = npfctl_table_replace(npf, req, resp);
+		break;
+	default:
+		error = ENOTTY;
+		break;
+	}
+	nvlist_add_number(resp, "errno", error);
 	return error;
 }

--- a/src/kern/npf_impl.h
+++ b/src/kern/npf_impl.h
@@ -300,11 +300,7 @@ void		npf_worker_signal(npf_t *);
 void		npf_worker_register(npf_t *, npf_workfunc_t);
 void		npf_worker_unregister(npf_t *, npf_workfunc_t);
 
-int		npfctl_save(npf_t *, u_long, void *);
-int		npfctl_load(npf_t *, u_long, void *);
-int		npfctl_rule(npf_t *, u_long, void *);
-int		npfctl_conn_lookup(npf_t *, u_long, void *);
-int		npfctl_table_replace(npf_t *, u_long, void *);
+int		npfctl_run_op(npf_t *, unsigned, const nvlist_t *, nvlist_t *);
 int		npfctl_table(npf_t *, void *);
 
 void		npf_stats_inc(npf_t *, npf_stats_t);
@@ -414,7 +410,7 @@ int		npf_ruleset_add(npf_ruleset_t *, const char *, npf_rule_t *);
 int		npf_ruleset_remove(npf_ruleset_t *, const char *, uint64_t);
 int		npf_ruleset_remkey(npf_ruleset_t *, const char *,
 		    const void *, size_t);
-nvlist_t *	npf_ruleset_list(npf_t *, npf_ruleset_t *, const char *);
+int		npf_ruleset_list(npf_t *, npf_ruleset_t *, const char *, nvlist_t *);
 int		npf_ruleset_flush(npf_ruleset_t *, const char *);
 void		npf_ruleset_gc(npf_ruleset_t *);
 

--- a/src/kern/npf_rproc.c
+++ b/src/kern/npf_rproc.c
@@ -33,7 +33,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf_rproc.c,v 1.19 2019/07/23 00:52:01 rmind Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/types.h>
@@ -260,7 +260,7 @@ npf_rprocset_insert(npf_rprocset_t *rpset, npf_rproc_t *rp)
 }
 
 int
-npf_rprocset_export(const npf_rprocset_t *rpset, nvlist_t *npf_dict)
+npf_rprocset_export(const npf_rprocset_t *rpset, nvlist_t *nvl)
 {
 	const npf_rproc_t *rp;
 
@@ -275,7 +275,7 @@ npf_rprocset_export(const npf_rprocset_t *rpset, nvlist_t *npf_dict)
 #endif
 		nvlist_add_string(rproc, "name", rp->rp_name);
 		nvlist_add_number(rproc, "flags", rp->rp_flags);
-		nvlist_append_nvlist_array(npf_dict, "rprocs", rproc);
+		nvlist_append_nvlist_array(nvl, "rprocs", rproc);
 		nvlist_destroy(rproc);
 	}
 	return 0;

--- a/src/kern/npf_tableset.c
+++ b/src/kern/npf_tableset.c
@@ -281,7 +281,7 @@ npf_tableset_reload(npf_t *npf, npf_tableset_t *nts, npf_tableset_t *ots)
 }
 
 int
-npf_tableset_export(npf_t *npf, const npf_tableset_t *ts, nvlist_t *npf_dict)
+npf_tableset_export(npf_t *npf, const npf_tableset_t *ts, nvlist_t *nvl)
 {
 	const npf_table_t *t;
 
@@ -298,7 +298,7 @@ npf_tableset_export(npf_t *npf, const npf_tableset_t *ts, nvlist_t *npf_dict)
 		nvlist_add_number(table, "type", t->t_type);
 		nvlist_add_number(table, "id", tid);
 
-		nvlist_append_nvlist_array(npf_dict, "tables", table);
+		nvlist_append_nvlist_array(nvl, "tables", table);
 		nvlist_destroy(table);
 	}
 	return 0;

--- a/src/kern/npfkern.3
+++ b/src/kern/npfkern.3
@@ -1,5 +1,5 @@
 .\"
-.\" Copyright (c) 2015-2019 Mindaugas Rasiukevicius <rmind at netbsd org>
+.\" Copyright (c) 2015-2020 Mindaugas Rasiukevicius <rmind at netbsd org>
 .\" All rights reserved.
 .\"
 .\" Redistribution and use in source and binary forms, with or without
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd February 26, 2019
+.Dd April 22, 2020
 .Dt libnpfkern 3
 .Os
 .Sh NAME
@@ -44,6 +44,8 @@
 "const npf_ifops_t *ifops"
 .Ft int
 .Fn npfk_load "npf_t *npf" "void *ref" "npf_error_t *err"
+.Ft int
+.Fn npfk_socket_load "npf_t *npf" "int sock"
 .Ft void
 .Fn npfk_gc "npf_t *npf"
 .Ft void
@@ -125,12 +127,12 @@ This routine should only be used if the instance was created with
 flag.
 .\" ---
 .It Fn npfk_destroy "npf"
-Destroy the instance of the NPF kernel compaining, freeing all resources
+Destroy the instance of the NPF kernel component, freeing all resources
 used by it.
 .\" ---
 .It Fn npfk_load "npf" "ref" "err"
 Load a new configuration into the NPF instance.
-The new configuration is specified by a
+The new configuration is specified by the
 .Fa ref
 parameter.
 It is a reference to the configuration built by the
@@ -140,10 +142,25 @@ function from the
 library.
 .Pp
 Returns zero on success and error number on failure.
+The configuration structure referenced by
+.Fa ref
+will be left unmodified.
 In a case of failure, additionally returns extra information in a
 structure specified by the
 .Fa err
 parameter.
+.\" ---
+.It Fn npfk_socket_load "npf" "sock"
+Load a new configuration into the NPF instance.
+The new configuration should be passed through a socket, specified by the
+.Fa sock
+parameter.
+It should be sent using the
+.Fn npf_config_submit
+function (with file descriptor being a socket) from the
+.Xr libnpf 3
+library.
+Returns zero on success and -1 on failure.
 .\" ---
 .It Fn npfk_thread_register "npf"
 Register a "processing context" i.e. a thread which will perform the
@@ -186,7 +203,7 @@ This function returns zero if the packet was "passed" and error number
 otherwise.
 A regular "block" is indicated by the
 .Dv ENETUNREACH
-error nubmer.
+error number.
 .\" ---
 .It Fn npfk_ifmap_attach "npf" "ifp"
 Attach the virtual network interface to the NPF instance.

--- a/src/kern/npfkern.h
+++ b/src/kern/npfkern.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2015 Mindaugas Rasiukevicius <rmind at netbsd org>
+ * Copyright (c) 2015-2020 Mindaugas Rasiukevicius <rmind at netbsd org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,17 +65,22 @@ int	npfk_sysinit(unsigned);
 void	npfk_sysfini(void);
 
 npf_t *	npfk_create(int, const npf_mbufops_t *, const npf_ifops_t *);
-int	npfk_load(npf_t *, void *, npf_error_t *);
+int	npfk_load(npf_t *, const void *, npf_error_t *);
+int	npfk_socket_load(npf_t *, int);
 void	npfk_gc(npf_t *);
 void	npfk_destroy(npf_t *);
 
 void	npfk_thread_register(npf_t *);
 void	npfk_thread_unregister(npf_t *);
+
 int	npfk_packet_handler(npf_t *, struct mbuf **, struct ifnet *, int);
+
 void	npfk_ifmap_attach(npf_t *, struct ifnet *);
 void	npfk_ifmap_detach(npf_t *, struct ifnet *);
+
 int	npfk_param_get(npf_t *, const char *, int *);
 int	npfk_param_set(npf_t *, const char *, int);
+
 void	npfk_stats(npf_t *, uint64_t *);
 void	npfk_stats_clear(npf_t *);
 

--- a/src/kern/stand/npf_stand.h
+++ b/src/kern/stand/npf_stand.h
@@ -476,8 +476,8 @@ typedef int modcmd_t;
 
 struct cpu_info { unsigned id; };
 
-#define	_IOR(g,n,t)		0
-#define	_IOW(g,n,t)		0
-#define	_IOWR(g,n,t)		0
+#define	_IOR(g,n,t)		((n) - 100)
+#define	_IOW(g,n,t)		((n) - 100)
+#define	_IOWR(g,n,t)		((n) - 100)
 
 #endif

--- a/src/kern/stand/npfkern.c
+++ b/src/kern/stand/npfkern.c
@@ -1,4 +1,5 @@
 /*-
+ * Copyright (c) 2020 Mindaugas Rasiukevicius <rmind at netbsd org>
  * Copyright (c) 2015 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
@@ -24,12 +25,42 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sys/types.h>
 #include <stdbool.h>
+#include <inttypes.h>
+
+#include "../npf_impl.h"
+#include "../npfkern.h"
 
 struct npf;
 
-bool	npf_active_p(void);
-void	npf_ifaddr_syncall(struct npf *);
+/*
+ * npfk_socket_load: receive the NPF configuration change request
+ * and process it (e.g. (re)load the active configuration).
+ *
+ * => Returns 0 on success and -1 on error.
+ * => Assumes a blocking socket.
+ */
+__dso_public int
+npfk_socket_load(npf_t *npf, int sock)
+{
+	nvlist_t *req, *resp;
+	uint64_t op;
+	int error;
+
+	req = nvlist_recv(sock, 0);
+	if (__predict_false(req == NULL)) {
+		return -1;
+	}
+	resp = nvlist_create(0);
+	op = dnvlist_get_number(req, "operation", UINT64_MAX);
+	(void)npfctl_run_op(npf, op, req, resp);
+	nvlist_destroy(req);
+
+	error = nvlist_send(sock, resp);
+	nvlist_destroy(resp);
+	return error;
+}
 
 bool
 npf_active_p(void)

--- a/src/libnpf/libnpf.3
+++ b/src/libnpf/libnpf.3
@@ -1,4 +1,4 @@
-.\"	$NetBSD: libnpf.3,v 1.9 2019/07/23 14:18:20 wiz Exp $
+.\"	$NetBSD$
 .\"
 .\" Copyright (c) 2011-2019 The NetBSD Foundation, Inc.
 .\" All rights reserved.
@@ -281,7 +281,8 @@ If the value of
 is
 .Dv NULL ,
 then insert into the main ruleset.
-The rule must not be referenced after insertion.
+The rule will be consumed (the relevant resourced will be freed) and it
+must not be referenced after insertion.
 .\" ---
 .It Fn npf_rule_exists_p "ncf" "name"
 Check whether the rule with a given name is already in the configuration.

--- a/src/libnpf/npf.h
+++ b/src/libnpf/npf.h
@@ -84,7 +84,7 @@ nl_config_t *	npf_config_import(const void *, size_t);
 void *		npf_config_export(nl_config_t *, size_t *);
 bool		npf_config_active_p(nl_config_t *);
 bool		npf_config_loaded_p(nl_config_t *);
-void *		npf_config_build(nl_config_t *);
+const void *	npf_config_build(nl_config_t *);
 
 int		npf_alg_load(nl_config_t *, const char *);
 

--- a/src/npfctl/npfctl.h
+++ b/src/npfctl/npfctl.h
@@ -226,10 +226,10 @@ void		npfctl_setparam(const char *, int);
  * For the systems which do not define TH_ECE and TW_CRW.
  */
 #ifndef TH_ECE
-#define	TH_ECE	  0x40
+#define	TH_ECE		0x40
 #endif
 #ifndef TH_CWR
-#define	TH_CWR	  0x80
+#define	TH_CWR		0x80
 #endif
 
 #endif

--- a/src/npftest/libnpftest/npf_test_subr.c
+++ b/src/npftest/libnpftest/npf_test_subr.c
@@ -90,6 +90,7 @@ npf_test_load(const void *buf, size_t len, bool verbose)
 {
 	nvlist_t *npf_dict;
 	npf_error_t error;
+	int ret;
 
 	npf_dict = nvlist_unpack(buf, len, 0);
 	if (!npf_dict) {
@@ -97,9 +98,9 @@ npf_test_load(const void *buf, size_t len, bool verbose)
 		return EINVAL;
 	}
 	load_npf_config_ifs(npf_dict, verbose);
-
-	// Note: npf_dict will be consumed by npf_load().
-	return npfk_load(npf_getkernctx(), npf_dict, &error);
+	ret = npfk_load(npf_getkernctx(), npf_dict, &error);
+	nvlist_destroy(npf_dict);
+	return ret;
 }
 
 ifnet_t *


### PR DESCRIPTION
- Add npfk_socket_load() to receive and load the config.
- Add npfctl_run_op() to have a single entry point for operations.
- Add npf_xfer_fd() and modify npf_config_submit() to detect socket.
- libnpf: fix some memory leaks.