### PR TITLE
Various NPF fixes/improvements.

### DIFF
--- a/app/docker-compose.yaml
+++ b/app/docker-compose.yaml
@@ -20,6 +20,25 @@ services:
     volumes:
       - ../:/src
 
+  npf-router-dev:
+    build:
+      context: ..
+      dockerfile: app/conf/npf-router.Dockerfile
+      target: npf-router-builder
+    image: npf_router_builder
+    privileged: true
+    depends_on:
+      - npf-pkg
+    hostname: npf-router
+    networks:
+      default:
+      testnet:
+        ipv4_address: 10.0.0.254
+    volumes:
+      - ../:/src
+    command:
+      - "/bin/true"
+
   npf-router:
     build:
       context: ..
@@ -33,8 +52,6 @@ services:
       default:
       testnet:
         ipv4_address: 10.0.0.2
-    volumes:
-      - ../:/src
     command:
       - "/app/run.sh"
 

--- a/app/src/Makefile
+++ b/app/src/Makefile
@@ -40,8 +40,8 @@ endif
 #
 ifeq ($(DEBUG),1)
 CFLAGS+=	-O0 -DDEBUG -fno-omit-frame-pointer
-CFLAGS+=	-fsanitize=address
-LDFLAGS+=	-fsanitize=address
+CFLAGS+=	-fsanitize=address -fsanitize=undefined
+LDFLAGS+=	-fsanitize=address -fsanitize=undefined
 else
 CFLAGS+=	-DNDEBUG
 endif

--- a/src/kern/Makefile
+++ b/src/kern/Makefile
@@ -55,7 +55,7 @@ endif
 
 OBJS=		$(shell awk '/^file/ { print $$2 }' files.npf | \
 		    sed 's:\(.*\)net/npf/\(.*\).c:\2.o:g' | \
-		    egrep -v '^(npf_os|npf_ext_|npf_ifaddr|if_npflog|lpm)')
+		    egrep -v '^(npf_os|npf_ext_log|npf_ifaddr|if_npflog|lpm)')
 
 OBJS+=		stand/npfkern.o stand/bpf_filter.o
 OBJS+=		stand/murmurhash.o stand/tls_pth.o

--- a/src/kern/npf_alg.c
+++ b/src/kern/npf_alg.c
@@ -189,7 +189,7 @@ npf_alg_unregister(npf_t *npf, npf_alg_t *alg)
 	atomic_store_relaxed(&afuncs->match, NULL);
 	atomic_store_relaxed(&afuncs->translate, NULL);
 	atomic_store_relaxed(&afuncs->inspect, NULL);
-	npf_ebr_full_sync(npf->ebr);
+	npf_config_sync(npf);
 
 	/*
 	 * Finally, unregister the ALG.  We leave the 'destroy' callback
@@ -226,7 +226,7 @@ npf_alg_match(npf_cache_t *npc, npf_nat_t *nt, int di)
 
 	KASSERTMSG(npf_iscached(npc, NPC_IP46), "expecting protocol number");
 
-	s = npf_ebr_enter(npf->ebr);
+	s = npf_config_read_enter(npf);
 	count = atomic_load_relaxed(&aset->alg_count);
 	for (unsigned i = 0; i < count; i++) {
 		const npfa_funcs_t *f = &aset->alg_funcs[i];
@@ -238,7 +238,7 @@ npf_alg_match(npf_cache_t *npc, npf_nat_t *nt, int di)
 			break;
 		}
 	}
-	npf_ebr_exit(npf->ebr, s);
+	npf_config_read_exit(npf, s);
 	return match;
 }
 
@@ -259,7 +259,7 @@ npf_alg_exec(npf_cache_t *npc, npf_nat_t *nt, bool forw)
 	unsigned count;
 	int s;
 
-	s = npf_ebr_enter(npf->ebr);
+	s = npf_config_read_enter(npf);
 	count = atomic_load_relaxed(&aset->alg_count);
 	for (unsigned i = 0; i < count; i++) {
 		const npfa_funcs_t *f = &aset->alg_funcs[i];
@@ -270,7 +270,7 @@ npf_alg_exec(npf_cache_t *npc, npf_nat_t *nt, bool forw)
 			translate_func(npc, nt, forw);
 		}
 	}
-	npf_ebr_exit(npf->ebr, s);
+	npf_config_read_exit(npf, s);
 }
 
 /*
@@ -299,7 +299,7 @@ npf_alg_conn(npf_cache_t *npc, int di)
 	unsigned count;
 	int s;
 
-	s = npf_ebr_enter(npf->ebr);
+	s = npf_config_read_enter(npf);
 	count = atomic_load_relaxed(&aset->alg_count);
 	for (unsigned i = 0; i < count; i++) {
 		const npfa_funcs_t *f = &aset->alg_funcs[i];
@@ -310,7 +310,7 @@ npf_alg_conn(npf_cache_t *npc, int di)
 			break;
 		}
 	}
-	npf_ebr_exit(npf->ebr, s);
+	npf_config_read_exit(npf, s);
 	return con;
 }
 

--- a/src/kern/npf_alg_pptp.c
+++ b/src/kern/npf_alg_pptp.c
@@ -275,14 +275,14 @@ pptp_gre_destroy_state(npf_t *npf, pptp_gre_state_t *gre_state, npf_addr_t **ips
 	if (gre_state->flags & GRE_STATE_ESTABLISHED) {
 		npf_connkey_t key;
 
-		/* Initialise the forward GRE connection key. */
+		/* Initialize the forward GRE connection key. */
 		ids[NPF_SRC] = gre_state->call_id[SERVER_CALL_ID];
 		ids[NPF_DST] = 0;
 		npf_connkey_setkey((void *)&key, IPPROTO_GRE, ips, ids,
 		    sizeof(uint32_t), true);
 
 		/* Lookup the associated PPTP GRE connection state. */
-		con = npf_conndb_lookup(npf->conn_db, &key, &forw);
+		con = npf_conndb_lookup(npf, &key, &forw);
 		if (con != NULL) {
 			/*
 			 * Mark the GRE connection as expired.

--- a/src/kern/npf_conn.c
+++ b/src/kern/npf_conn.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2018 Mindaugas Rasiukevicius <rmind at netbsd org>
+ * Copyright (c) 2014-2020 Mindaugas Rasiukevicius <rmind at noxt eu>
  * Copyright (c) 2010-2014 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
@@ -81,14 +81,14 @@
  *	on lookup and should be released by the caller.  It guarantees that
  *	the connection will not be destroyed, although it may be expired.
  *
- * Synchronisation
+ * Synchronization
  *
  *	Connection database is accessed in a lock-less manner by the main
  *	routines: npf_conn_inspect() and npf_conn_establish().  Since they
  *	are always called from a software interrupt, the database is
- *	protected using passive serialisation.  The main place which can
- *	destroy a connection is npf_conn_worker().  The database itself
- *	can be replaced and destroyed in npf_conn_reload().
+ *	protected using EBR.  The main place which can destroy a connection
+ *	is npf_conn_worker().  The database itself can be replaced and
+ *	destroyed in npf_conn_reload().
  *
  * ALG support
  *
@@ -306,7 +306,6 @@ npf_conn_lookup(const npf_cache_t *npc, const int di, bool *forw)
 {
 	npf_t *npf = npc->npc_ctx;
 	const nbuf_t *nbuf = npc->npc_nbuf;
-	npf_conndb_t *conn_db;
 	npf_conn_t *con;
 	npf_connkey_t key;
 
@@ -314,8 +313,7 @@ npf_conn_lookup(const npf_cache_t *npc, const int di, bool *forw)
 	if (!npf_conn_conkey(npc, &key, true)) {
 		return NULL;
 	}
-	conn_db = atomic_load_relaxed(&npf->conn_db);
-	con = npf_conndb_lookup(conn_db, &key, forw);
+	con = npf_conndb_lookup(npf, &key, forw);
 	if (con == NULL) {
 		return NULL;
 	}
@@ -360,7 +358,7 @@ npf_conn_inspect(npf_cache_t *npc, const int di, int *error)
 	}
 	KASSERT(!nbuf_flag_p(nbuf, NBUF_DATAREF_RESET));
 
-	/* Main lookup of the connection. */
+	/* The main lookup of the connection (acquires a reference). */
 	if ((con = npf_conn_lookup(npc, di, &forw)) == NULL) {
 		return NULL;
 	}
@@ -424,8 +422,8 @@ npf_conn_establish(npf_cache_t *npc, int di, bool global)
 	npf_stats_inc(npf, NPF_STAT_CONN_CREATE);
 
 	mutex_init(&con->c_lock, MUTEX_DEFAULT, IPL_SOFTNET);
-	con->c_flags = (di & PFIL_ALL);
-	con->c_refcnt = 0;
+	atomic_store_relaxed(&con->c_flags, di & PFIL_ALL);
+	atomic_store_relaxed(&con->c_refcnt, 0);
 	con->c_rproc = NULL;
 	con->c_nat = NULL;
 
@@ -459,7 +457,7 @@ npf_conn_establish(npf_cache_t *npc, int di, bool global)
 	 * a reference for the caller before we make it visible.
 	 */
 	conn_update_atime(con);
-	con->c_refcnt = 1;
+	atomic_store_relaxed(&con->c_refcnt, 1);
 
 	/*
 	 * Insert both keys (entries representing directions) of the
@@ -505,7 +503,7 @@ npf_conn_destroy(npf_t *npf, npf_conn_t *con)
 {
 	const unsigned idx __unused = NPF_CONNCACHE(con->c_alen);
 
-	KASSERT(con->c_refcnt == 0);
+	KASSERT(atomic_load_relaxed(&con->c_refcnt) == 0);
 
 	if (con->c_nat) {
 		/* Release any NAT structures. */
@@ -546,8 +544,9 @@ npf_conn_setnat(const npf_cache_t *npc, npf_conn_t *con,
 	npf_conndb_t *conn_db;
 	npf_addr_t *taddr;
 	in_port_t tport;
+	uint32_t flags;
 
-	KASSERT(con->c_refcnt > 0);
+	KASSERT(atomic_load_relaxed(&con->c_refcnt) > 0);
 
 	npf_nat_gettrans(nt, &taddr, &tport);
 	KASSERT(ntype == NPF_NATOUT || ntype == NPF_NATIN);
@@ -559,12 +558,13 @@ npf_conn_setnat(const npf_cache_t *npc, npf_conn_t *con,
 
 	/* Acquire the lock and check for the races. */
 	mutex_enter(&con->c_lock);
-	if (__predict_false(con->c_flags & CONN_EXPIRE)) {
+	flags = atomic_load_relaxed(&con->c_flags);
+	if (__predict_false(flags & CONN_EXPIRE)) {
 		/* The connection got expired. */
 		mutex_exit(&con->c_lock);
 		return EINVAL;
 	}
-	KASSERT((con->c_flags & CONN_REMOVED) == 0);
+	KASSERT((flags & CONN_REMOVED) == 0);
 
 	if (__predict_false(con->c_nat != NULL)) {
 		/* Race with a duplicate packet. */
@@ -607,11 +607,14 @@ npf_conn_setnat(const npf_cache_t *npc, npf_conn_t *con,
 
 /*
  * npf_conn_expire: explicitly mark connection as expired.
+ *
+ * => Must be called with: a) reference held  b) the relevant lock held.
+ *    The relevant lock should prevent from connection destruction, e.g.
+ *    npf_t::conn_lock or npf_natpolicy_t::n_lock.
  */
 void
 npf_conn_expire(npf_conn_t *con)
 {
-	/* KASSERT(con->c_refcnt > 0); XXX: npf_nat_freepolicy() */
 	atomic_or_uint(&con->c_flags, CONN_EXPIRE);
 }
 
@@ -622,7 +625,7 @@ bool
 npf_conn_pass(const npf_conn_t *con, npf_match_info_t *mi, npf_rproc_t **rp)
 {
 	KASSERT(atomic_load_relaxed(&con->c_refcnt) > 0);
-	if (__predict_true(con->c_flags & CONN_PASS)) {
+	if (__predict_true(atomic_load_relaxed(&con->c_flags) & CONN_PASS)) {
 		mi->mi_rid = atomic_load_relaxed(&con->c_rid);
 		mi->mi_retfl = atomic_load_relaxed(&con->c_retfl);
 		*rp = con->c_rproc;
@@ -717,7 +720,7 @@ npf_conn_remove(npf_conndb_t *cd, npf_conn_t *con)
 {
 	/* Remove both entries of the connection. */
 	mutex_enter(&con->c_lock);
-	if ((con->c_flags & CONN_REMOVED) == 0) {
+	if ((atomic_load_relaxed(&con->c_flags) & CONN_REMOVED) == 0) {
 		npf_connkey_t *fw, *bk;
 		npf_conn_t *ret __diagused;
 
@@ -838,9 +841,9 @@ npf_conn_import(npf_t *npf, npf_conndb_t *cd, const nvlist_t *cdict,
 	npf_conn_t *con;
 	npf_connkey_t *fw, *bk;
 	const nvlist_t *nat, *conkey;
+	unsigned flags, alen, idx;
 	const char *ifname;
 	const void *state;
-	unsigned alen, idx;
 	size_t len;
 
 	/*
@@ -857,8 +860,9 @@ npf_conn_import(npf_t *npf, npf_conndb_t *cd, const nvlist_t *cdict,
 	npf_stats_inc(npf, NPF_STAT_CONN_CREATE);
 
 	con->c_proto = dnvlist_get_number(cdict, "proto", 0);
-	con->c_flags = dnvlist_get_number(cdict, "flags", 0);
-	con->c_flags &= PFIL_ALL | CONN_ACTIVE | CONN_PASS;
+	flags = dnvlist_get_number(cdict, "flags", 0);
+	flags &= PFIL_ALL | CONN_ACTIVE | CONN_PASS;
+	atomic_store_relaxed(&con->c_flags, flags);
 	conn_update_atime(con);
 
 	ifname = dnvlist_get_string(cdict, "ifname", NULL);
@@ -921,7 +925,6 @@ int
 npf_conn_find(npf_t *npf, const nvlist_t *nvl, nvlist_t *outnvl)
 {
 	const nvlist_t *knvl;
-	npf_conndb_t *conn_db;
 	npf_conn_t *con;
 	npf_connkey_t key;
 	uint16_t dir;
@@ -932,8 +935,7 @@ npf_conn_find(npf_t *npf, const nvlist_t *nvl, nvlist_t *outnvl)
 	if (!knvl || !npf_connkey_import(knvl, &key)) {
 		return EINVAL;
 	}
-	conn_db = atomic_load_relaxed(&npf->conn_db);
-	con = npf_conndb_lookup(conn_db, &key, &forw);
+	con = npf_conndb_lookup(npf, &key, &forw);
 	if (con == NULL) {
 		return ESRCH;
 	}

--- a/src/kern/npf_conn.h
+++ b/src/kern/npf_conn.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2009-2019 The NetBSD Foundation, Inc.
+ * Copyright (c) 2009-2020 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * This material is based upon work partially supported by The
@@ -160,7 +160,7 @@ void		npf_conndb_sysfini(npf_t *);
 npf_conndb_t *	npf_conndb_create(void);
 void		npf_conndb_destroy(npf_conndb_t *);
 
-npf_conn_t *	npf_conndb_lookup(npf_conndb_t *, const npf_connkey_t *, bool *);
+npf_conn_t *	npf_conndb_lookup(npf_t *, const npf_connkey_t *, bool *);
 bool		npf_conndb_insert(npf_conndb_t *, const npf_connkey_t *,
 		    npf_conn_t *, bool);
 npf_conn_t *	npf_conndb_remove(npf_conndb_t *, npf_connkey_t *);

--- a/src/kern/npf_ctl.c
+++ b/src/kern/npf_ctl.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2009-2019 The NetBSD Foundation, Inc.
+ * Copyright (c) 2009-2020 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * This material is based upon work partially supported by The
@@ -459,7 +459,7 @@ npf_mk_singlenat(npf_t *npf, const nvlist_t *nat, nvlist_t *resp,
 	}
 
 	/* Allocate a new NAT policy and assign it to the rule. */
-	np = npf_nat_newpolicy(npf, nat, ntset);
+	np = npf_natpolicy_create(npf, nat, ntset);
 	if (np == NULL) {
 		NPF_ERR_DEBUG(resp);
 		error = ENOMEM;

--- a/src/kern/npf_ext_log.c
+++ b/src/kern/npf_ext_log.c
@@ -33,7 +33,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf_ext_log.c,v 1.15 2018/09/29 14:41:36 rmind Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/types.h>
 #include <sys/module.h>
@@ -152,11 +152,8 @@ npf_log(npf_cache_t *npc, void *meta, const npf_match_info_t *mi, int *decision)
 	return true;
 }
 
-/*
- * Module interface.
- */
-static int
-npf_ext_log_modcmd(modcmd_t cmd, void *arg)
+__dso_public int
+npf_ext_log_init(npf_t *npf)
 {
 	static const npf_ext_ops_t npf_log_ops = {
 		.version	= NPFEXT_LOG_VER,
@@ -165,33 +162,33 @@ npf_ext_log_modcmd(modcmd_t cmd, void *arg)
 		.dtor		= npf_log_dtor,
 		.proc		= npf_log
 	};
+	npf_ext_log_id = npf_ext_register(npf, "log", &npf_log_ops);
+	return npf_ext_log_id ? 0 : EEXIST;
+}
+
+__dso_public int
+npf_ext_log_fini(npf_t *npf)
+{
+	return npf_ext_unregister(npf, npf_ext_log_id);
+}
+
+#ifdef _KERNEL
+static int
+npf_ext_log_modcmd(modcmd_t cmd, void *arg)
+{
 	npf_t *npf = npf_getkernctx();
-	int error;
 
 	switch (cmd) {
 	case MODULE_CMD_INIT:
-		/*
-		 * Initialise the NPF logging extension.
-		 */
-		npf_ext_log_id = npf_ext_register(npf, "log", &npf_log_ops);
-		if (!npf_ext_log_id) {
-			return EEXIST;
-		}
-		break;
-
+		return npf_ext_log_init(npf);
 	case MODULE_CMD_FINI:
-		error = npf_ext_unregister(npf, npf_ext_log_id);
-		if (error) {
-			return error;
-		}
+		return npf_ext_log_fini(npf);
 		break;
-
 	case MODULE_CMD_AUTOUNLOAD:
-		/* Allow auto-unload only if NPF permits it. */
 		return npf_autounload_p() ? 0 : EBUSY;
-
 	default:
 		return ENOTTY;
 	}
 	return 0;
 }
+#endif

--- a/src/kern/npf_ext_normalize.c
+++ b/src/kern/npf_ext_normalize.c
@@ -26,7 +26,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf_ext_normalize.c,v 1.9 2018/09/29 14:41:36 rmind Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/types.h>
 #include <sys/module.h>
@@ -54,8 +54,8 @@ static void *		npf_ext_normalize_id;
  * Normalisation parameters.
  */
 typedef struct {
-	u_int		n_minttl;
-	u_int		n_maxmss;
+	unsigned	n_minttl;
+	unsigned	n_maxmss;
 	bool		n_random_id;
 	bool		n_no_df;
 } npf_normalize_t;
@@ -96,7 +96,7 @@ npf_normalize_dtor(npf_rproc_t *rp, void *params)
 }
 
 /*
- * npf_normalize_ip4: routine to normalize IPv4 header (randomise ID,
+ * npf_normalize_ip4: routine to normalize IPv4 header (randomize ID,
  * clear "don't fragment" and/or enforce minimum TTL).
  */
 static inline void
@@ -106,11 +106,11 @@ npf_normalize_ip4(npf_cache_t *npc, npf_normalize_t *np)
 	uint16_t cksum = ip->ip_sum;
 	uint16_t ip_off = ip->ip_off;
 	uint8_t ttl = ip->ip_ttl;
-	u_int minttl = np->n_minttl;
+	unsigned minttl = np->n_minttl;
 
 	KASSERT(np->n_random_id || np->n_no_df || minttl);
 
-	/* Randomise IPv4 ID. */
+	/* Randomize IPv4 ID. */
 	if (np->n_random_id) {
 		uint16_t oid = ip->ip_id, nid;
 
@@ -156,7 +156,7 @@ npf_normalize(npf_cache_t *npc, void *params, const npf_match_info_t *mi,
 		return true;
 	}
 
-	/* Normalise IPv4.  Nothing to do for IPv6. */
+	/* Normalize IPv4.  Nothing to do for IPv6. */
 	if (npf_iscached(npc, NPC_IP4) && (np->n_random_id || np->n_minttl)) {
 		npf_normalize_ip4(npc, np);
 	}
@@ -204,8 +204,8 @@ npf_normalize(npf_cache_t *npc, void *params, const npf_match_info_t *mi,
 	return true;
 }
 
-static int
-npf_ext_normalize_modcmd(modcmd_t cmd, void *arg)
+__dso_public int
+npf_ext_normalize_init(npf_t *npf)
 {
 	static const npf_ext_ops_t npf_normalize_ops = {
 		.version	= NPFEXT_NORMALIZE_VER,
@@ -214,27 +214,33 @@ npf_ext_normalize_modcmd(modcmd_t cmd, void *arg)
 		.dtor		= npf_normalize_dtor,
 		.proc		= npf_normalize
 	};
+	npf_ext_normalize_id = npf_ext_register(npf,
+	    "normalize", &npf_normalize_ops);
+	return npf_ext_normalize_id ? 0 : EEXIST;
+}
+
+__dso_public int
+npf_ext_normalize_fini(npf_t *npf)
+{
+	return npf_ext_unregister(npf, npf_ext_normalize_id);
+}
+
+#ifdef _KERNEL
+static int
+npf_ext_normalize_modcmd(modcmd_t cmd, void *arg)
+{
 	npf_t *npf = npf_getkernctx();
 
 	switch (cmd) {
 	case MODULE_CMD_INIT:
-		/*
-		 * Initialise normalisation module.  Register the "normalize"
-		 * extension and its calls.
-		 */
-		npf_ext_normalize_id =
-		    npf_ext_register(npf, "normalize", &npf_normalize_ops);
-		return npf_ext_normalize_id ? 0 : EEXIST;
-
+		return npf_ext_normalize_init(npf);
 	case MODULE_CMD_FINI:
-		/* Unregister the normalisation rule procedure. */
 		return npf_ext_unregister(npf, npf_ext_normalize_id);
-
 	case MODULE_CMD_AUTOUNLOAD:
 		return npf_autounload_p() ? 0 : EBUSY;
-
 	default:
 		return ENOTTY;
 	}
 	return 0;
 }
+#endif

--- a/src/kern/npf_ext_rndblock.c
+++ b/src/kern/npf_ext_rndblock.c
@@ -31,7 +31,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf_ext_rndblock.c,v 1.8 2018/09/29 14:41:36 rmind Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/types.h>
 #include <sys/cprng.h>
@@ -134,11 +134,8 @@ npf_ext_rndblock(npf_cache_t *npc, void *meta, const npf_match_info_t *mi,
 	return true;
 }
 
-/*
- * Module interface.
- */
-static int
-npf_ext_rndblock_modcmd(modcmd_t cmd, void *arg)
+__dso_public int
+npf_ext_rndblock_init(npf_t *npf)
 {
 	static const npf_ext_ops_t npf_rndblock_ops = {
 		.version	= NPFEXT_RNDBLOCK_VER,
@@ -147,32 +144,46 @@ npf_ext_rndblock_modcmd(modcmd_t cmd, void *arg)
 		.dtor		= npf_ext_rndblock_dtor,
 		.proc		= npf_ext_rndblock
 	};
+
+	/*
+	 * Initialize the NPF extension.  Register the "rndblock" extension
+	 * calls (constructor, destructor, the processing routine, etc).
+	 */
+	npf_ext_rndblock_id = npf_ext_register(npf, "rndblock",
+	    &npf_rndblock_ops);
+	return npf_ext_rndblock_id ? 0 : EEXIST;
+}
+
+__dso_public int
+npf_ext_rndblock_fini(npf_t *npf)
+{
+	/*
+	 * Remove the rndblock extension.  NPF may return an if there
+	 * are active references and it cannot drain them.
+	 */
+	return npf_ext_unregister(npf, npf_ext_rndblock_id);
+}
+
+#ifdef _KERNEL
+/*
+ * Kernel module interface.
+ */
+static int
+npf_ext_rndblock_modcmd(modcmd_t cmd, void *arg)
+{
 	npf_t *npf = npf_getkernctx();
 
 	switch (cmd) {
 	case MODULE_CMD_INIT:
-		/*
-		 * Initialise the NPF extension module.  Register the
-		 * "rndblock" extensions calls (constructor, destructor,
-		 * the processing * routine, etc).
-		 */
-		npf_ext_rndblock_id = npf_ext_register(npf, "rndblock",
-		    &npf_rndblock_ops);
-		return npf_ext_rndblock_id ? 0 : EEXIST;
-
+		return npf_ext_rndblock_init(npf);
 	case MODULE_CMD_FINI:
-		/*
-		 * Unregister our rndblock extension.  NPF may return an
-		 * if there are references and it cannot drain them.
-		 */
-		return npf_ext_unregister(npf, npf_ext_rndblock_id);
-
+		return npf_ext_rndblock_fini(npf);
 	case MODULE_CMD_AUTOUNLOAD:
 		/* Allow auto-unload only if NPF permits it. */
 		return npf_autounload_p() ? 0 : EBUSY;
-
 	default:
 		return ENOTTY;
 	}
 	return 0;
 }
+#endif

--- a/src/kern/npf_impl.h
+++ b/src/kern/npf_impl.h
@@ -475,10 +475,10 @@ void		npf_portmap_flush(npf_portmap_t *);
 /* NAT. */
 void		npf_nat_sysinit(void);
 void		npf_nat_sysfini(void);
-npf_natpolicy_t *npf_nat_newpolicy(npf_t *, const nvlist_t *, npf_ruleset_t *);
-int		npf_nat_policyexport(const npf_natpolicy_t *, nvlist_t *);
-void		npf_nat_freepolicy(npf_natpolicy_t *);
-bool		npf_nat_cmppolicy(npf_natpolicy_t *, npf_natpolicy_t *);
+npf_natpolicy_t *npf_natpolicy_create(npf_t *, const nvlist_t *, npf_ruleset_t *);
+int		npf_natpolicy_export(const npf_natpolicy_t *, nvlist_t *);
+void		npf_natpolicy_destroy(npf_natpolicy_t *);
+bool		npf_natpolicy_cmp(npf_natpolicy_t *, npf_natpolicy_t *);
 void		npf_nat_setid(npf_natpolicy_t *, uint64_t);
 uint64_t	npf_nat_getid(const npf_natpolicy_t *);
 void		npf_nat_freealg(npf_natpolicy_t *, npf_alg_t *);

--- a/src/kern/npf_os.c
+++ b/src/kern/npf_os.c
@@ -517,6 +517,12 @@ npf_active_p(void)
 
 #ifdef __NetBSD__
 
+/*
+ * Epoch-Based Reclamation (EBR) wrappers: in NetBSD, we rely on the
+ * passive serialization mechanism (see pserialize(9) manual page),
+ * which provides sufficient guarantees for NPF.
+ */
+
 ebr_t *
 npf_ebr_create(void)
 {

--- a/src/kern/npf_tableset.c
+++ b/src/kern/npf_tableset.c
@@ -39,9 +39,9 @@
  * Warning (not applicable for the userspace npfkern):
  *
  *	The thmap_put()/thmap_del() are not called from the interrupt
- *	context and are protected by a mutex(9), therefore they do not
- *	SPL wrappers -- see the comment at the top of the npf_conndb.c
- *	source file.
+ *	context and are protected by an IPL_NET mutex(9), therefore they
+ *	do not need SPL wrappers -- see the comment at the top of the
+ *	npf_conndb.c source file.
  */
 
 #ifdef _KERNEL
@@ -678,6 +678,7 @@ npf_table_lookup(npf_table_t *t, const int alen, const npf_addr_t *addr)
 
 	switch (t->t_type) {
 	case NPF_TABLE_IPSET:
+		/* Note: the caller is in the npf_config_read_enter(). */
 		found = thmap_get(t->t_map, addr, alen) != NULL;
 		break;
 	case NPF_TABLE_LPM:

--- a/src/kern/npfkern.h
+++ b/src/kern/npfkern.h
@@ -85,6 +85,19 @@ void	npfk_stats(npf_t *, uint64_t *);
 void	npfk_stats_clear(npf_t *);
 
 /*
+ * Extensions.
+ */
+
+int	npf_ext_log_init(npf_t *);
+int	npf_ext_log_fini(npf_t *);
+
+int	npf_ext_normalize_init(npf_t *);
+int	npf_ext_normalize_fini(npf_t *);
+
+int	npf_ext_rndblock_init(npf_t *);
+int	npf_ext_rndblock_fini(npf_t *);
+
+/*
  * ALGs.
  */
 

--- a/src/kern/stand/ebr_wrappers.c
+++ b/src/kern/stand/ebr_wrappers.c
@@ -33,7 +33,7 @@
 #include "../npf_impl.h"
 
 /*
- * EBR wrappers.
+ * Epoch-Based Reclamation (EBR) wrappers.
  */
 
 ebr_t *

--- a/src/kern/stand/npf_stand.h
+++ b/src/kern/stand/npf_stand.h
@@ -157,6 +157,7 @@ again:
 #define	membar_producer()	__sync_synchronize()
 #define	atomic_inc_uint(x)	__sync_fetch_and_add((x), 1)
 #define	atomic_inc_uint_nv(x)	__sync_add_and_fetch((x), 1)
+#define	atomic_inc_ulong_nv(x)	__sync_add_and_fetch((x), 1)
 #define	atomic_dec_uint(x)	__sync_sub_and_fetch((x), 1)
 #define	atomic_dec_uint_nv(x)	__sync_sub_and_fetch((x), 1)
 #define	atomic_or_uint(x, v)	__sync_fetch_and_or((x), (v))
@@ -342,6 +343,7 @@ npfkern_percpu_foreach(percpu_t *pc, percpu_callback_t cb, void *arg)
  */
 
 #define	cprng_fast32()			((uint32_t)random())
+#define	ip_randomid(o,s)		((uint16_t)random())
 
 /*
  * Hashing.

--- a/src/libnpf/Makefile
+++ b/src/libnpf/Makefile
@@ -27,6 +27,8 @@ CFLAGS+=	-Wsuggest-attribute=noreturn #-Wjump-misses-init
 
 ifeq ($(DEBUG),1)
 CFLAGS+=	-Og -DDEBUG -fno-omit-frame-pointer
+CFLAGS+=	-fsanitize=address -fsanitize=undefined
+LDFLAGS+=	-fsanitize=address -fsanitize=undefined
 else
 CFLAGS+=	-DNDEBUG
 endif

--- a/src/npfctl/Makefile
+++ b/src/npfctl/Makefile
@@ -28,6 +28,8 @@ CFLAGS+=	-Wold-style-definition
 
 ifeq ($(DEBUG),1)
 CFLAGS+=	-Og -DDEBUG -fno-omit-frame-pointer
+CFLAGS+=	-fsanitize=address -fsanitize=undefined
+LDFLAGS+=	-fsanitize=address -fsanitize=undefined
 else
 CFLAGS+=	-DNDEBUG
 endif


### PR DESCRIPTION
- npf_conndb_lookup: protect the connection lookup with EBR primitives,
  instead of incorrectly relying on the handler running at IPL_SOFNET.
- npf_natpolicy_create/npf_natpolicy_destroy: set the initial reference
  and do not wait for reference draining on destruction; just destroy the
  policy on the last reference drop instead.
- npfkern: compile-in the NPF extensions (kernel-side modules).
- Add npf-router-dev Docker service for NPF-Router.
- Enable UBsan; misc fixes.