### PR TITLE
More NPF fixes.

### DIFF
--- a/app/conf/npf-router.Dockerfile
+++ b/app/conf/npf-router.Dockerfile
@@ -1,7 +1,7 @@
 ##########################################################################
 # NPF + DPDK builder
 #
-FROM npf-pkg AS npf-router-builder
+FROM npf-pkg AS npf-router-dev
 WORKDIR /build
 COPY . /build/npf
 
@@ -23,8 +23,8 @@ RUN dnf config-manager --set-enabled PowerTools
 RUN dnf install -y kernel-modules kernel-modules-extra dpdk libibverbs
 RUN dnf install -y man-pages net-tools traceroute
 
-COPY --from=npf-router-builder /pkg/*.rpm /pkg/
+COPY --from=npf-router-dev /pkg/*.rpm /pkg/
 RUN dnf install -y /pkg/*.x86_64.rpm
 
 WORKDIR /app
-COPY --from=npf-router-builder /build/bin/* /app/
+COPY --from=npf-router-dev /build/bin/* /app/

--- a/app/docker-compose.yaml
+++ b/app/docker-compose.yaml
@@ -24,8 +24,8 @@ services:
     build:
       context: ..
       dockerfile: app/conf/npf-router.Dockerfile
-      target: npf-router-builder
-    image: npf_router_builder
+      target: npf-router-dev
+    image: npf_router_dev
     privileged: true
     depends_on:
       - npf-pkg

--- a/app/src/npf_router.c
+++ b/app/src/npf_router.c
@@ -349,7 +349,7 @@ main(int argc, char **argv)
 			}
 			err(EXIT_FAILURE, "accept");
 		}
-		puts("- Reloading NPF config");
+		puts("- NPF configuration control call");
 		if (npfk_socket_load(router->npf, sock) == -1) {
 			warnx("npfk_socket_load");
 		}

--- a/src/kern/npf_ctl.c
+++ b/src/kern/npf_ctl.c
@@ -121,8 +121,14 @@ npf_mk_table_entries(npf_table_t *t, const nvlist_t *req, nvlist_t *resp)
 			break;
 		}
 		error = npf_table_insert(t, alen, addr, mask);
-		if (error) {
-			NPF_ERR_DEBUG(resp);
+		if (__predict_false(error)) {
+			if (error == EEXIST) {
+				nvlist_add_stringf(resp, "error-msg",
+				    "table `%s' has a duplicate entry",
+				    nvlist_get_string(req, "name"));
+			} else {
+				NPF_ERR_DEBUG(resp);
+			}
 			break;
 		}
 	}

--- a/src/libnpf/npf.c
+++ b/src/libnpf/npf.c
@@ -691,7 +691,9 @@ npf_rule_export(nl_rule_t *rl, size_t *length)
 bool
 npf_rule_exists_p(nl_config_t *ncf, const char *name)
 {
-	return _npf_dataset_lookup(ncf->ncf_dict, "rules", "name", name);
+	const char *key = nvlist_exists_nvlist_array(ncf->ncf_dict,
+	    "rules") ? "rules" : "__rules"; // config may not be built yet
+	return _npf_dataset_lookup(ncf->ncf_dict, key, "name", name);
 }
 
 int

--- a/src/npfctl/npf_cmd.c
+++ b/src/npfctl/npf_cmd.c
@@ -405,7 +405,7 @@ typedef struct {
 	uint16_t	alen;
 	const char *	ifname;
 	bool		nat;
-	bool		wide;
+	bool		nowide;
 	bool		name;
 	int		width;
 	FILE *		fp;
@@ -413,9 +413,9 @@ typedef struct {
 
 static int
 npfctl_conn_print(unsigned alen, const npf_addr_t *a, const in_port_t *p,
-    const char *ifname, void *v)
+    const char *ifname, void *arg)
 {
-	npf_conn_filter_t *fil = v;
+	npf_conn_filter_t *fil = arg;
 	FILE *fp = fil->fp;
 	char *src, *dst;
 
@@ -432,7 +432,7 @@ npfctl_conn_print(unsigned alen, const npf_addr_t *a, const in_port_t *p,
 	src = npfctl_print_addrmask(alen, fmt, &a[0], NPF_NO_NETMASK);
 	dst = npfctl_print_addrmask(alen, fmt, &a[1], NPF_NO_NETMASK);
 
-	if (fil->wide) {
+	if (fil->nowide) {
 		fprintf(fp, "%s:%d %s:%d", src, p[0], dst, p[1]);
 	} else {
 		fprintf(fp, "%*.*s:%-5d %*.*s:%-5d", w, w, src, p[0],
@@ -478,12 +478,12 @@ npfctl_conn_list(int fd, int argc, char **argv)
 		case 'N':
 			f.name = true;
 			break;
-		case 'w':
-			f.wide = true;
+		case 'W':
+			f.nowide = true;
 			break;
 		default:
 			fprintf(stderr,
-			    "Usage: %s list [-46hnNw] [-i <ifname>]\n",
+			    "Usage: %s list [-46hnNW] [-i <ifname>]\n",
 			    getprogname());
 			exit(EXIT_FAILURE);
 		}
@@ -494,7 +494,7 @@ npfctl_conn_list(int fd, int argc, char **argv)
 
 	if (header) {
 		fprintf(f.fp, "%*.*s %*.*s\n",
-		    w, w, "From address:port ", w, w, "To address:port ");
+		    w, w, "# from address:port ", w, w, "to address:port ");
 	}
 	npf_conn_list(fd, npfctl_conn_print, &f);
 	return 0;

--- a/src/npfctl/npfctl.8
+++ b/src/npfctl/npfctl.8
@@ -27,7 +27,7 @@
 .\" ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd August 26, 2019
+.Dd May 12, 2020
 .Dt NPFCTL 8
 .Os
 .Sh NAME
@@ -175,7 +175,7 @@ Print various statistics.
 Process the configuration file, print the byte-code of each rule
 and dump the raw configuration.
 This is primarily for developer use.
-.It Ic list Oo Fl 46hNnw Oc Op Fl i Ar ifname
+.It Ic list Oo Fl 46hNnW Oc Op Fl i Ar ifname
 Display a list of tracked connections:
 .Bl -tag -width xxxxxxxxx -compact -offset 3n
 .It Fl 4
@@ -188,8 +188,8 @@ Don't display a header.
 Try to resolve addresses.
 .It Fl n
 Only show NAT connections.
-.It Fl w
-Don't restrict display width.
+.It Fl W
+Restrict the display width.
 .It Fl i Ar ifname
 Display only connections through the named interface.
 .El

--- a/src/npfctl/npfctl.c
+++ b/src/npfctl/npfctl.c
@@ -232,7 +232,7 @@ npfctl_print_addrmask(int alen, const char *fmt, const npf_addr_t *addr,
 		break;
 	}
 	default:
-		assert(false);
+		abort();
 	}
 	sockaddr_snprintf(buf, buflen, fmt, (const void *)&ss);
 	if (mask && mask != NPF_NO_NETMASK) {

--- a/src/npfctl/npfctl.h
+++ b/src/npfctl/npfctl.h
@@ -198,6 +198,7 @@ void		npfctl_bpf_table(npf_bpf_t *, u_int, u_int);
 #define	NPFCTL_NAT_STATIC	2
 
 void		npfctl_config_init(bool);
+void		npfctl_config_build(void);
 int		npfctl_config_send(int);
 nl_config_t *	npfctl_config_ref(void);
 int		npfctl_config_show(int);
@@ -231,10 +232,10 @@ void		npfctl_setparam(const char *, int);
 /*
  * For the systems which do not define TH_ECE and TW_CRW.
  */
-#ifndef TH_ECE
+#ifndef	TH_ECE
 #define	TH_ECE		0x40
 #endif
-#ifndef TH_CWR
+#ifndef	TH_CWR
 #define	TH_CWR		0x80
 #endif
 


### PR DESCRIPTION
- npfctl: fix the regression and restore the default group behaviour.
- npfkern: add user-friendly message in npf_mk_table_entries().
- libnpf: handle non-built config case in npf_rule_exists_p().