### PR TITLE
NPF fixes and improvements.

### DIFF
--- a/app/docker-compose.yaml
+++ b/app/docker-compose.yaml
@@ -65,8 +65,8 @@ services:
     networks:
       testnet:
         ipv4_address: 10.0.0.3
-    depends_on:
-      - npf-router
+    #depends_on:
+    #  - npf-router
     command:
       - "/app/run_host.sh"
 

--- a/app/src/npf_router.c
+++ b/app/src/npf_router.c
@@ -217,10 +217,9 @@ router_create(void)
 	/*
 	 * NPF instance and its operations.
 	 */
-	npf_dpdk_init(router);
 	npfk_sysinit(1);
 
-	router->npf = npf_dpdk_create(0);
+	router->npf = npf_dpdk_create(0, router);
 	if (!router->npf) {
 		goto err;
 	}

--- a/app/src/npf_router.h
+++ b/app/src/npf_router.h
@@ -96,8 +96,7 @@ typedef struct worker {
  * NPF DPDK operations, network interface and configuration loading.
  */
 
-void		npf_dpdk_init(npf_router_t *);
-npf_t *		npf_dpdk_create(int);
+npf_t *		npf_dpdk_create(int, npf_router_t *);
 
 int		ifnet_setup(npf_router_t *, const unsigned, const unsigned);
 int		ifnet_register(npf_router_t *, const char *);

--- a/src/kern/npf.c
+++ b/src/kern/npf.c
@@ -67,7 +67,8 @@ npfk_sysfini(void)
 }
 
 __dso_public npf_t *
-npfk_create(int flags, const npf_mbufops_t *mbufops, const npf_ifops_t *ifops)
+npfk_create(int flags, const npf_mbufops_t *mbufops,
+    const npf_ifops_t *ifops, void *arg)
 {
 	npf_t *npf;
 
@@ -75,6 +76,7 @@ npfk_create(int flags, const npf_mbufops_t *mbufops, const npf_ifops_t *ifops)
 	npf->ebr = npf_ebr_create();
 	npf->stats_percpu = percpu_alloc(NPF_STATS_SIZE);
 	npf->mbufops = mbufops;
+	npf->arg = arg;
 
 	npf_param_init(npf);
 	npf_state_sysinit(npf);
@@ -153,6 +155,12 @@ npfk_thread_unregister(npf_t *npf)
 {
 	npf_ebr_full_sync(npf->ebr);
 	npf_ebr_unregister(npf->ebr);
+}
+
+__dso_public void *
+npfk_getarg(npf_t *npf)
+{
+	return npf->arg;
 }
 
 void

--- a/src/kern/npf_conn.c
+++ b/src/kern/npf_conn.c
@@ -379,11 +379,12 @@ npf_conn_inspect(npf_cache_t *npc, const int di, int *error)
 	 * If this is multi-end state, then specially tag the packet
 	 * so it will be just passed-through on other interfaces.
 	 */
-	if (atomic_load_relaxed(&con->c_ifid) == 0 &&
-	    nbuf_add_tag(nbuf, NPF_NTAG_PASS) != 0) {
-		npf_conn_release(con);
-		*error = ENOMEM;
-		return NULL;
+	if (atomic_load_relaxed(&con->c_ifid) == 0) {
+		/*
+		 * Note: if tagging fails, then give this packet a chance
+		 * to go through a regular ruleset.
+		 */
+		(void)nbuf_add_tag(nbuf, NPF_NTAG_PASS);
 	}
 	return con;
 }

--- a/src/kern/npf_ifaddr.c
+++ b/src/kern/npf_ifaddr.c
@@ -33,7 +33,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf_ifaddr.c,v 1.5 2019/01/19 21:19:32 rmind Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/types.h>
@@ -54,10 +54,10 @@ lookup_ifnet_table(npf_t *npf, ifnet_t *ifp)
 	const char *ifname;
 	npf_config_t *nc;
 	npf_table_t *t;
-	u_int tid;
+	unsigned tid;
 
 	/* Get the interface name and prefix it. */
-	ifname = ifops->getname(ifp);
+	ifname = ifops->getname(npf, ifp);
 	snprintf(tname, sizeof(tname), ".ifnet-%s", ifname);
 
 	KERNEL_LOCK(1, NULL);

--- a/src/kern/npf_impl.h
+++ b/src/kern/npf_impl.h
@@ -209,9 +209,12 @@ struct npf {
 	ebr_t *			ebr;
 	npf_config_t *		config;
 
-	/* BPF byte-code context. */
+	/*
+	 * BPF byte-code context, mbuf operations an arbitrary user argument.
+	 */
 	bpf_ctx_t *		bpfctx;
 	const npf_mbufops_t *	mbufops;
+	void *			arg;
 
 	/* Parameters. */
 	npf_paraminfo_t *	paraminfo;

--- a/src/kern/npf_mbuf.c
+++ b/src/kern/npf_mbuf.c
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2009-2012 The NetBSD Foundation, Inc.
+ * Copyright (c) 2009-2020 The NetBSD Foundation, Inc.
  * All rights reserved.
  *
  * This material is based upon work partially supported by The
@@ -60,6 +60,7 @@ __KERNEL_RCSID(0, "$NetBSD$");
 #define	m_makewritable(m,o,l,f)	(nbuf)->nb_mops->ensure_writable((m), (o+l))
 #define	mtod(m,t)		((t)((nbuf)->nb_mops->getdata(m)))
 #define	m_flags_p(m,f)		true
+#define	M_UNWRITABLE(m, l)	false
 #else
 #define	m_next_ptr(m)		(m)->m_next
 #define	m_buflen(m)		((size_t)(m)->m_len)
@@ -73,7 +74,7 @@ __KERNEL_RCSID(0, "$NetBSD$");
 void
 nbuf_init(npf_t *npf, nbuf_t *nbuf, struct mbuf *m, const ifnet_t *ifp)
 {
-	u_int ifid = npf_ifmap_getid(npf, ifp);
+	unsigned ifid = npf_ifmap_getid(npf, ifp);
 
 	KASSERT(m_flags_p(m, M_PKTHDR));
 	nbuf->nb_mops = npf->mbufops;
@@ -104,7 +105,7 @@ size_t
 nbuf_offset(const nbuf_t *nbuf)
 {
 	const struct mbuf *m = nbuf->nb_mbuf;
-	const u_int off = (uintptr_t)nbuf->nb_nptr - mtod(m, uintptr_t);
+	const unsigned off = (uintptr_t)nbuf->nb_nptr - mtod(m, uintptr_t);
 	const int poff = m_length(nbuf->nb_mbuf0) - m_length(m) + off;
 
 	return poff;
@@ -139,7 +140,7 @@ void *
 nbuf_advance(nbuf_t *nbuf, size_t len, size_t ensure)
 {
 	struct mbuf *m = nbuf->nb_mbuf;
-	u_int off, wmark;
+	unsigned off, wmark;
 	uint8_t *d;
 
 	/* Offset with amount to advance. */
@@ -240,7 +241,7 @@ void *
 nbuf_ensure_writable(nbuf_t *nbuf, size_t len)
 {
 	struct mbuf *m = nbuf->nb_mbuf;
-	const u_int off = (uintptr_t)nbuf->nb_nptr - mtod(m, uintptr_t);
+	const unsigned off = (uintptr_t)nbuf->nb_nptr - mtod(m, uintptr_t);
 	const int tlen = off + len;
 	bool head_buf;
 
@@ -296,15 +297,15 @@ nbuf_cksum_barrier(nbuf_t *nbuf, int di)
 }
 
 /*
- * nbuf_add_tag: add a tag to specified network buffer.
+ * nbuf_add_tag: associate a tag with the network buffer.
  *
- * => Returns 0 on success or errno on failure.
+ * => Returns 0 on success or error number on failure.
  */
 int
 nbuf_add_tag(nbuf_t *nbuf, uint32_t val)
 {
-#ifdef _KERNEL
 	struct mbuf *m = nbuf->nb_mbuf0;
+#ifdef _KERNEL
 	struct m_tag *mt;
 	uint32_t *dat;
 
@@ -319,21 +320,23 @@ nbuf_add_tag(nbuf_t *nbuf, uint32_t val)
 	m_tag_prepend(m, mt);
 	return 0;
 #else
-	(void)nbuf; (void)val;
-	return ENOTSUP;
+	if (!nbuf->nb_mops->set_tag) {
+		return ENOTSUP;
+	}
+	return nbuf->nb_mops->set_tag(m, val);
 #endif
 }
 
 /*
- * nbuf_find_tag: find a tag in specified network buffer.
+ * nbuf_find_tag: find a tag associated with a network buffer.
  *
- * => Returns 0 on success or errno on failure.
+ * => Returns 0 on success or error number on failure.
  */
 int
 nbuf_find_tag(nbuf_t *nbuf, uint32_t *val)
 {
-#ifdef _KERNEL
 	struct mbuf *m = nbuf->nb_mbuf0;
+#ifdef _KERNEL
 	struct m_tag *mt;
 
 	KASSERT(m_flags_p(m, M_PKTHDR));
@@ -345,7 +348,9 @@ nbuf_find_tag(nbuf_t *nbuf, uint32_t *val)
 	*val = *(uint32_t *)(mt + 1);
 	return 0;
 #else
-	(void)nbuf; (void)val;
-	return ENOTSUP;
+	if (!nbuf->nb_mops->get_tag) {
+		return ENOTSUP;
+	}
+	return nbuf->nb_mops->get_tag(m, val);
 #endif
 }

--- a/src/kern/npf_os.c
+++ b/src/kern/npf_os.c
@@ -110,11 +110,11 @@ const struct cdevsw npf_cdevsw = {
 	.d_flag = D_OTHER | D_MPSAFE
 };
 
-static const char *	npf_ifop_getname(ifnet_t *);
-static ifnet_t *	npf_ifop_lookup(const char *);
-static void		npf_ifop_flush(void *);
-static void *		npf_ifop_getmeta(const ifnet_t *);
-static void		npf_ifop_setmeta(ifnet_t *, void *);
+static const char *	npf_ifop_getname(npf_t *, ifnet_t *);
+static ifnet_t *	npf_ifop_lookup(npf_t *, const char *);
+static void		npf_ifop_flush(npf_t *, void *);
+static void *		npf_ifop_getmeta(npf_t *, const ifnet_t *);
+static void		npf_ifop_setmeta(npf_t *, ifnet_t *, void *);
 
 static const unsigned	nworkers = 1;
 
@@ -316,19 +316,19 @@ npf_autounload_p(void)
  */
 
 static const char *
-npf_ifop_getname(ifnet_t *ifp)
+npf_ifop_getname(npf_t *npf __unused, ifnet_t *ifp)
 {
 	return ifp->if_xname;
 }
 
 static ifnet_t *
-npf_ifop_lookup(const char *name)
+npf_ifop_lookup(npf_t *npf __unused, const char *name)
 {
 	return ifunit(name);
 }
 
 static void
-npf_ifop_flush(void *arg)
+npf_ifop_flush(npf_t *npf __unused, void *arg)
 {
 	ifnet_t *ifp;
 
@@ -342,13 +342,13 @@ npf_ifop_flush(void *arg)
 }
 
 static void *
-npf_ifop_getmeta(const ifnet_t *ifp)
+npf_ifop_getmeta(npf_t *npf __unused, const ifnet_t *ifp)
 {
 	return ifp->if_npf_private;
 }
 
 static void
-npf_ifop_setmeta(ifnet_t *ifp, void *arg)
+npf_ifop_setmeta(npf_t *npf __unused, ifnet_t *ifp, void *arg)
 {
 	ifp->if_npf_private = arg;
 }

--- a/src/kern/npf_sendpkt.c
+++ b/src/kern/npf_sendpkt.c
@@ -33,7 +33,7 @@
 
 #ifdef _KERNEL
 #include <sys/cdefs.h>
-__KERNEL_RCSID(0, "$NetBSD: npf_sendpkt.c,v 1.21 2018/09/29 18:00:35 rmind Exp $");
+__KERNEL_RCSID(0, "$NetBSD$");
 
 #include <sys/param.h>
 #include <sys/types.h>
@@ -56,7 +56,7 @@ __KERNEL_RCSID(0, "$NetBSD: npf_sendpkt.c,v 1.21 2018/09/29 18:00:35 rmind Exp $
 #define	DEFAULT_IP_TTL		(ip_defttl)
 
 #if defined(_NPF_STANDALONE)
-#define	m_gethdr(t, f)		(npf)->mbufops->alloc(0, 0)
+#define	m_gethdr(t, f)		(npf)->mbufops->alloc((npf), 0, 0)
 #define	m_freem(m)		(npc)->npc_ctx->mbufops->free(m)
 #define	mtod(m,t)		((t)((npc)->npc_ctx->mbufops->getdata(m)))
 #endif

--- a/src/kern/npfkern.3
+++ b/src/kern/npfkern.3
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 22, 2020
+.Dd May 13, 2020
 .Dt libnpfkern 3
 .Os
 .Sh NAME
@@ -41,7 +41,7 @@
 .Fn npfk_sysfini "void"
 .Ft npf_t *
 .Fn npfk_create "int flags" "const npf_mbufops_t *mbufops" \
-"const npf_ifops_t *ifops"
+"const npf_ifops_t *ifops" "void *arg"
 .Ft int
 .Fn npfk_load "npf_t *npf" "void *ref" "npf_error_t *err"
 .Ft int
@@ -97,7 +97,7 @@ Destroy any resources used by the
 library, e.g. stop and exit the worker threads.
 This function must be called once finished using the component.
 .\" ---
-.It Fn npfk_create "flags" "mbufops" "ifops"
+.It Fn npfk_create "flags" "mbufops" "ifops" "arg"
 Construct and return a new instance of the NPF kernel component.
 The parameter
 .Fa flags
@@ -106,6 +106,7 @@ should be 0 or
 The
 .Dv NPF_NO_GC
 flag disables garbage collection of connections and other objects.
+.Pp
 The parameters
 .Fa mbufops
 and
@@ -114,6 +115,12 @@ specify the operation vectors, that is, structures containing the set of
 functions required to operate a network buffer (mbuf) or a network interface.
 This functions abstract the real representation and shall be provided by
 the caller.
+.Pp
+The
+.Fa arg
+parameter can be used to associate an arbitrary user context with an NPF
+instance, so that this value could later be obtained by the functions in
+the operation vectors.
 .Pp
 Returns a reference (pointer) to the instance on success and
 .Dv NULL

--- a/src/kern/npfkern.h
+++ b/src/kern/npfkern.h
@@ -43,15 +43,15 @@ struct ifnet;
 #define	NPF_NO_GC	0x01
 
 typedef struct {
-	const char *	(*getname)(struct ifnet *);
-	struct ifnet *	(*lookup)(const char *);
-	void		(*flush)(void *);
-	void *		(*getmeta)(const struct ifnet *);
-	void		(*setmeta)(struct ifnet *, void *);
+	const char *	(*getname)(npf_t *, struct ifnet *);
+	struct ifnet *	(*lookup)(npf_t *, const char *);
+	void		(*flush)(npf_t *, void *);
+	void *		(*getmeta)(npf_t *, const struct ifnet *);
+	void		(*setmeta)(npf_t *, struct ifnet *, void *);
 } npf_ifops_t;
 
 typedef struct {
-	struct mbuf *	(*alloc)(int, int);
+	struct mbuf *	(*alloc)(npf_t *, unsigned, size_t);
 	void		(*free)(struct mbuf *);
 	void *		(*getdata)(const struct mbuf *);
 	struct mbuf *	(*getnext)(struct mbuf *);
@@ -59,16 +59,19 @@ typedef struct {
 	size_t		(*getchainlen)(const struct mbuf *);
 	bool		(*ensure_contig)(struct mbuf **, size_t);
 	bool		(*ensure_writable)(struct mbuf **, size_t);
+	int		(*get_tag)(const struct mbuf *, uint32_t *);
+	int		(*set_tag)(struct mbuf *, uint32_t);
 } npf_mbufops_t;
 
 int	npfk_sysinit(unsigned);
 void	npfk_sysfini(void);
 
-npf_t *	npfk_create(int, const npf_mbufops_t *, const npf_ifops_t *);
+npf_t *	npfk_create(int, const npf_mbufops_t *, const npf_ifops_t *, void *);
 int	npfk_load(npf_t *, const void *, npf_error_t *);
 int	npfk_socket_load(npf_t *, int);
 void	npfk_gc(npf_t *);
 void	npfk_destroy(npf_t *);
+void *	npfk_getarg(npf_t *);
 
 void	npfk_thread_register(npf_t *);
 void	npfk_thread_unregister(npf_t *);

--- a/src/kern/stand/npf_stand.h
+++ b/src/kern/stand/npf_stand.h
@@ -433,8 +433,6 @@ npfkern_ip_reass_packet(void *x)
 #define	ip_defttl		64
 #define	max_linkhdr		0
 
-#define	M_UNWRITABLE(m, l)	false
-
 /*
  * Misc.
  */

--- a/src/npftest/libnpftest/npf_mbuf_subr.c
+++ b/src/npftest/libnpftest/npf_mbuf_subr.c
@@ -15,7 +15,7 @@
 
 #if defined(_NPF_STANDALONE)
 struct mbuf *
-npfkern_m_get(int flags, int space)
+npfkern_m_get(npf_t *npf __unused, unsigned flags, size_t space)
 {
 	unsigned mlen = offsetof(struct mbuf, m_data0[space]);
 	struct mbuf *m;
@@ -30,7 +30,7 @@ npfkern_m_get(int flags, int space)
 }
 #else
 struct mbuf *
-npfkern_m_get(int flags, int space)
+npfkern_m_get(npf_t *npf __unused, unsigned flags, size_t space)
 {
 	return m_get(flags, space);
 }
@@ -92,7 +92,7 @@ npfkern_m_ensure_contig(struct mbuf **m0, size_t len)
 	char *dptr;
 
 	tlen = npfkern_m_length(*m0);
-	if ((m1 = npfkern_m_get(M_PKTHDR, tlen)) == NULL) {
+	if ((m1 = npfkern_m_get(NULL, M_PKTHDR, tlen)) == NULL) {
 		return false;
 	}
 	m1->m_pkthdr.len = m1->m_len = tlen;

--- a/src/npftest/libnpftest/npf_test.h
+++ b/src/npftest/libnpftest/npf_test.h
@@ -73,8 +73,8 @@ struct mbuf {
 #define	M_NOWAIT		0x00001
 #define M_PKTHDR		0x00002
 
-#define	m_get(x, y)		npfkern_m_get(0, MLEN)
-#define	m_gethdr(x, y)		npfkern_m_get(M_PKTHDR, MLEN)
+#define	m_get(x, y)		npfkern_m_get(NULL, 0, MLEN)
+#define	m_gethdr(x, y)		npfkern_m_get(NULL, M_PKTHDR, MLEN)
 #define	m_length(m)		npfkern_m_length(m)
 #define	m_freem(m)		npfkern_m_freem(m)
 #define	mtod(m, t)		((t)((m)->m_data))
@@ -87,7 +87,7 @@ struct mbuf {
 const npf_mbufops_t	npftest_mbufops;
 const npf_ifops_t	npftest_ifops;
 
-struct mbuf *	npfkern_m_get(int, int);
+struct mbuf *	npfkern_m_get(npf_t *, unsigned, size_t);
 size_t		npfkern_m_length(const struct mbuf *);
 void		npfkern_m_freem(struct mbuf *);
 

--- a/src/npftest/libnpftest/npf_test_subr.c
+++ b/src/npftest/libnpftest/npf_test_subr.c
@@ -43,14 +43,15 @@ struct ifnet {
 static TAILQ_HEAD(, ifnet) npftest_ifnet_list =
     TAILQ_HEAD_INITIALIZER(npftest_ifnet_list);
 
-static const char *	npftest_ifop_getname(ifnet_t *);
-static void		npftest_ifop_flush(void *);
-static void *		npftest_ifop_getmeta(const ifnet_t *);
-static void		npftest_ifop_setmeta(ifnet_t *, void *);
+static const char *	npftest_ifop_getname(npf_t *, ifnet_t *);
+static ifnet_t *	npftest_ifop_lookup(npf_t *, const char *);
+static void		npftest_ifop_flush(npf_t *, void *);
+static void *		npftest_ifop_getmeta(npf_t *, const ifnet_t *);
+static void		npftest_ifop_setmeta(npf_t *, ifnet_t *, void *);
 
 const npf_ifops_t npftest_ifops = {
 	.getname	= npftest_ifop_getname,
-	.lookup		= npf_test_getif,
+	.lookup		= npftest_ifop_lookup,
 	.flush		= npftest_ifop_flush,
 	.getmeta	= npftest_ifop_getmeta,
 	.setmeta	= npftest_ifop_setmeta,
@@ -64,7 +65,7 @@ npf_test_init(int (*pton_func)(int, const char *, void *),
 	npf_t *npf;
 
 	npfk_sysinit(0);
-	npf = npfk_create(0, &npftest_mbufops, &npftest_ifops);
+	npf = npfk_create(0, &npftest_mbufops, &npftest_ifops, NULL);
 	npfk_thread_register(npf);
 	npf_setkernctx(npf);
 
@@ -128,6 +129,18 @@ npf_test_addif(const char *ifname, bool reg, bool verbose)
 	return ifp;
 }
 
+ifnet_t *
+npf_test_getif(const char *ifname)
+{
+	ifnet_t *ifp;
+
+	TAILQ_FOREACH(ifp, &npftest_ifnet_list, if_list) {
+		if (!strcmp(ifp->if_xname, ifname))
+			return ifp;
+	}
+	return NULL;
+}
+
 static void
 load_npf_config_ifs(nvlist_t *npf_dict, bool verbose)
 {
@@ -154,25 +167,19 @@ load_npf_config_ifs(nvlist_t *npf_dict, bool verbose)
 }
 
 static const char *
-npftest_ifop_getname(ifnet_t *ifp)
+npftest_ifop_getname(npf_t *npf __unused, ifnet_t *ifp)
 {
 	return ifp->if_xname;
 }
 
-ifnet_t *
-npf_test_getif(const char *ifname)
+static ifnet_t *
+npftest_ifop_lookup(npf_t *npf __unused, const char *ifname)
 {
-	ifnet_t *ifp;
-
-	TAILQ_FOREACH(ifp, &npftest_ifnet_list, if_list) {
-		if (!strcmp(ifp->if_xname, ifname))
-			return ifp;
-	}
-	return NULL;
+	return npf_test_getif(ifname);
 }
 
 static void
-npftest_ifop_flush(void *arg)
+npftest_ifop_flush(npf_t *npf __unused, void *arg)
 {
 	ifnet_t *ifp;
 
@@ -181,13 +188,13 @@ npftest_ifop_flush(void *arg)
 }
 
 static void *
-npftest_ifop_getmeta(const ifnet_t *ifp)
+npftest_ifop_getmeta(npf_t *npf __unused, const ifnet_t *ifp)
 {
 	return ifp->if_softc;
 }
 
 static void
-npftest_ifop_setmeta(ifnet_t *ifp, void *arg)
+npftest_ifop_setmeta(npf_t *npf __unused, ifnet_t *ifp, void *arg)
 {
 	ifp->if_softc = arg;
 }


### PR DESCRIPTION
- npfk_create: add an arbitrary user context (argument) which will be
  associated with the NPF instance, so that this value could later be
  obtained using npfk_getarg() by the functions in the operation vectors.
- Modify npf_ifops_t operations to take npf_t as a first parameter.
- Modify npf_mbufops_t::alloc to take npf_t as a first parameter.
  Also, add get_tag()/set_tag() operations to npf_mbufops_t.
- npf_conn_inspect: do not drop the packet if nbuf_add_tag() fails.
- Update bpf_filter.c from NetBSD: add BPF_MOD/BPF_XOR (from libpcap
  via christos@) and a fix for bpf_validate() (from alnsn@).