### PR TITLE
npfctl: refactor and improve parsing a little bit.

### DIFF
--- a/src/libnpf/npf.c
+++ b/src/libnpf/npf.c
@@ -259,6 +259,7 @@ _npf_xfer_fd(int fd, unsigned long cmd, nvlist_t *req, nvlist_t **resp)
 		goto err;
 	}
 	switch (st.st_mode & S_IFMT) {
+#if !defined(__NetBSD__)
 	case S_IFSOCK:
 		if (nvlist_send(fd, req) == -1) {
 			goto err;
@@ -267,6 +268,7 @@ _npf_xfer_fd(int fd, unsigned long cmd, nvlist_t *req, nvlist_t **resp)
 			goto err;
 		}
 		break;
+#endif
 #if !defined(_NPF_STANDALONE)
 	case S_IFBLK:
 	case S_IFCHR:

--- a/src/npfctl/npf_cmd.c
+++ b/src/npfctl/npf_cmd.c
@@ -31,8 +31,10 @@
 __RCSID("$NetBSD$");
 
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <errno.h>
 #include <err.h>
 
 #ifdef __NetBSD__

--- a/src/npfctl/npf_scan.l
+++ b/src/npfctl/npf_scan.l
@@ -249,3 +249,5 @@ any			return ANY;
 [ \t]		/* eat whitespace */
 
 :		return COLON;
+
+.		return INVALID;

--- a/src/npfctl/npf_var.c
+++ b/src/npfctl/npf_var.c
@@ -27,8 +27,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ * NPF variables are used to build the intermediate representation (IR)
+ * of the configuration grammar.  They represent primitive types (strings,
+ * numbers, etc) as well as complex types (address and mask, table, etc).
+ */
+
 #include <sys/cdefs.h>
-__RCSID("$NetBSD: npf_var.c,v 1.12 2019/01/19 21:19:32 rmind Exp $");
+__RCSID("$NetBSD$");
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/npfctl/npf_var.h
+++ b/src/npfctl/npf_var.h
@@ -47,6 +47,7 @@
 #define	NPFVAR_TCPFLAG		9
 #define	NPFVAR_ICMP		10
 #define	NPFVAR_INTERFACE	11
+#define	NPFVAR_PROTO		12
 
 #ifdef _NPFVAR_PRIVATE
 static const char *npfvar_types[ ] = {
@@ -61,7 +62,8 @@ static const char *npfvar_types[ ] = {
 	[NPFVAR_PROC_PARAM]	= "procedure-parameter",
 	[NPFVAR_TCPFLAG]	= "tcp-flag",
 	[NPFVAR_ICMP]		= "icmp",
-	[NPFVAR_INTERFACE]	= "interface-address"
+	[NPFVAR_INTERFACE]	= "interface-address",
+	[NPFVAR_PROTO]		= "proto",
 };
 #endif
 

--- a/src/npfctl/npfctl.c
+++ b/src/npfctl/npfctl.c
@@ -34,14 +34,17 @@ __RCSID("$NetBSD$");
 #include <sys/stat.h>
 #include <sys/socket.h>
 #include <sys/mman.h>
+#include <sys/un.h>
 #ifdef __NetBSD__
 #include <sys/module.h>
 #endif
 
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <errno.h>
 #include <err.h>
 
 #include "npfctl.h"

--- a/src/npfctl/npfctl.h
+++ b/src/npfctl/npfctl.h
@@ -186,7 +186,8 @@ void		npfctl_bpf_destroy(npf_bpf_t *);
 void		npfctl_bpf_group_enter(npf_bpf_t *, bool);
 void		npfctl_bpf_group_exit(npf_bpf_t *);
 
-void		npfctl_bpf_proto(npf_bpf_t *, sa_family_t, int);
+void		npfctl_bpf_ipver(npf_bpf_t *, sa_family_t);
+void		npfctl_bpf_proto(npf_bpf_t *, unsigned);
 void		npfctl_bpf_cidr(npf_bpf_t *, u_int, sa_family_t,
 		    const npf_addr_t *, const npf_netmask_t);
 void		npfctl_bpf_ports(npf_bpf_t *, u_int, in_port_t, in_port_t);
@@ -220,11 +221,11 @@ void		npfctl_build_rproc(const char *, npfvar_t *);
 void		npfctl_build_group(const char *, int, const char *, bool);
 void		npfctl_build_group_end(void);
 void		npfctl_build_rule(uint32_t, const char *, sa_family_t,
-		    const opt_proto_t *, const filt_opts_t *,
+		    const npfvar_t *, const filt_opts_t *,
 		    const char *, const char *);
 void		npfctl_build_natseg(int, int, unsigned, const char *,
 		    const addr_port_t *, const addr_port_t *,
-		    const opt_proto_t *, const filt_opts_t *, unsigned);
+		    const npfvar_t *, const filt_opts_t *, unsigned);
 void		npfctl_build_maprset(const char *, int, const char *);
 void		npfctl_build_table(const char *, u_int, const char *);
 


### PR DESCRIPTION
- Refactor parsing and byte-code generation to support multiple 'proto'
  options.  Parts contributed by christos at netbsd.
- Define grammar of lists for address and port filter criteria, making
  them more narrow than the generic list composition.
- Misc fixes for building on NetBSD, while here.