### PR TITLE
Various smaller fixes and fixes for NetBSD.

### DIFF
--- a/misc/npf_to_netbsd.sh
+++ b/misc/npf_to_netbsd.sh
@@ -17,7 +17,7 @@ scp ./kern/*npf*.{c,h} "$base_netbsd/sys/net/npf/"
 scp ./kern/npf-params.7 "$base_netbsd/usr.sbin/npf/"
 
 # npfctl
-scp ./npfctl/npf*.{c,h,l,y,5,8} "$base_netbsd/usr.sbin/npf/npfctl/"
+scp ./npfctl/npf?*.{c,h,l,y,5,8} "$base_netbsd/usr.sbin/npf/npfctl/"
 
 # libnpf
 scp ./libnpf/libnpf.3 "$base_netbsd/lib/libnpf/"

--- a/src/kern/npf_conf.c
+++ b/src/kern/npf_conf.c
@@ -42,7 +42,7 @@
  *	configuration will not be destroyed while accessing it.
  *
  *	For the cases (2) and (3), mutual exclusion (npf_t::config_lock)
- *	is used with, when necessarya, the writer-side barrier of EBR.
+ *	is used with, when necessary, the writer-side barrier of EBR.
  */
 
 #ifdef _KERNEL

--- a/src/kern/npf_connkey.c
+++ b/src/kern/npf_connkey.c
@@ -172,7 +172,7 @@ npf_connkey_getckey(const npf_connkey_t *key, unsigned *ifid, unsigned *di)
 }
 
 /*
- * npf_conn_adjkey: adjust the connection key by resetting the address/port.
+ * npf_conn_adjkey: adjust the connection key by setting the address/port.
  *
  * => The 'which' must either be NPF_SRC or NPF_DST.
  */

--- a/src/npfctl/npf_cmd.c
+++ b/src/npfctl/npf_cmd.c
@@ -239,11 +239,10 @@ npfctl_table_replace(int fd, int argc, char **argv)
 			newname = optarg;
 			break;
 		default:
-			fprintf(stderr,
+			errx(EXIT_FAILURE,
 			    "Usage: %s table \"table-name\" replace "
 			    "[-n \"name\"] [-t <type>] <table-file>\n",
 			    getprogname());
-			exit(EXIT_FAILURE);
 		}
 	}
 	argc -= optind;
@@ -473,7 +472,9 @@ npf_conn_list_v(int fd, unsigned alen, npf_conn_filter_t *f)
 	f->alen = alen;
 	f->v4 = alen == sizeof(struct in_addr);
 	f->pwidth = f->nowide ? 0 : ((f->v4 ? 15 : 40) + 1 + 5);
-	npf_conn_list(fd, npfctl_conn_print, f);
+	if (npf_conn_list(fd, npfctl_conn_print, f) != 0) {
+		err(EXIT_FAILURE, "npf_conn_list");
+	}
 }
 
 int
@@ -514,7 +515,7 @@ npfctl_conn_list(int fd, int argc, char **argv)
 			f.nowide = true;
 			break;
 		default:
-			err(EXIT_FAILURE,
+			errx(EXIT_FAILURE,
 			    "Usage: %s list [-46hnNW] [-i <ifname>]\n",
 			    getprogname());
 		}

--- a/src/npfctl/npfctl.c
+++ b/src/npfctl/npfctl.c
@@ -347,7 +347,7 @@ npfctl_open_dev(const char *path)
 	if (lstat(path, &st) == -1) {
 		err(EXIT_FAILURE, "fstat");
 	}
-	if (st.st_mode & S_IFMT) {
+	if ((st.st_mode & S_IFMT) == S_IFSOCK) {
 		struct sockaddr_un addr;
 
 		if ((fd = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {


### PR DESCRIPTION
npfkern:
- npf_conn_setnat: simplify and clean up.

libnpf:
- _npf_xfer_fd: fix the transfer by using nvlist_xfer_ioctl().

npfctl:
- npfctl_open_dev: test for a UNIX socket correctly.
- npf_conn_list_v: check the return value of npfctl_conn_list().
- npfctl_conn_list: fix the usage message.