### PR TITLE
Pass-through block-return packets so they are not subject to rules.

### DIFF
--- a/src/kern/npf.h
+++ b/src/kern/npf.h
@@ -122,6 +122,7 @@ void *		nbuf_ensure_writable(nbuf_t *, size_t);
 
 bool		nbuf_cksum_barrier(nbuf_t *, int);
 int		nbuf_add_tag(nbuf_t *, uint32_t);
+int		npf_mbuf_add_tag(nbuf_t *, struct mbuf *, uint32_t);
 int		nbuf_find_tag(nbuf_t *, uint32_t *);
 
 /*

--- a/src/kern/npf_mbuf.c
+++ b/src/kern/npf_mbuf.c
@@ -297,14 +297,13 @@ nbuf_cksum_barrier(nbuf_t *nbuf, int di)
 }
 
 /*
- * nbuf_add_tag: associate a tag with the network buffer.
+ * npf_mbuf_add_tag: associate a tag with the network buffer.
  *
  * => Returns 0 on success or error number on failure.
  */
 int
-nbuf_add_tag(nbuf_t *nbuf, uint32_t val)
+npf_mbuf_add_tag(nbuf_t *nbuf, struct mbuf *m, uint32_t val)
 {
-	struct mbuf *m = nbuf->nb_mbuf0;
 #ifdef _KERNEL
 	struct m_tag *mt;
 	uint32_t *dat;
@@ -325,6 +324,18 @@ nbuf_add_tag(nbuf_t *nbuf, uint32_t val)
 	}
 	return nbuf->nb_mops->set_tag(m, val);
 #endif
+}
+
+/*
+ * nbuf_add_tag: associate a tag with the network buffer.
+ *
+ * => Returns 0 on success or error number on failure.
+ */
+int
+nbuf_add_tag(nbuf_t *nbuf, uint32_t val)
+{
+	struct mbuf *m = nbuf->nb_mbuf0;
+	return npf_mbuf_add_tag(nbuf, m, val);
 }
 
 /*

--- a/src/kern/npf_sendpkt.c
+++ b/src/kern/npf_sendpkt.c
@@ -197,6 +197,9 @@ npf_return_tcp(npf_cache_t *npc)
 		}
 	}
 
+	/* Do not inspect the generated reject packets going out. */
+	(void)npf_mbuf_add_tag(npc->npc_nbuf, m, NPF_NTAG_PASS);
+
 	/* Pass to IP layer. */
 	if (npf_iscached(npc, NPC_IP4)) {
 		return ip_output(m, NULL, NULL, IP_FORWARDING, NULL, NULL);
@@ -214,6 +217,9 @@ static int
 npf_return_icmp(const npf_cache_t *npc)
 {
 	struct mbuf *m = nbuf_head_mbuf(npc->npc_nbuf);
+
+	/* Do not inspect the generated reject packets going out. */
+	(void)nbuf_add_tag(npc->npc_nbuf, NPF_NTAG_PASS);
 
 	if (npf_iscached(npc, NPC_IP4)) {
 		icmp_error(m, ICMP_UNREACH, ICMP_UNREACH_ADMIN_PROHIBIT, 0, 0);


### PR DESCRIPTION
This way the block-return packets are not dropped by accident and no
additional rules are needed to let block-return packets reliably out.

Patch contributed by Frank Kardel (kardel at netbsd.org).