### PR TITLE
Backport some fixes from NetBSD.

### DIFF
--- a/src/kern/npf-params.7
+++ b/src/kern/npf-params.7
@@ -89,7 +89,7 @@ The worker is self-tuning and will wake up more frequently if there are
 connections to expire; it will wake up less frequently, diverging towards
 the upper bound, if it does not encounter expired connections.
 Default: 50 (in milliseconds).
-.It Li gc.interval_min
+.It Li gc.interval_max
 The upper bound for the sleep time of the G/C worker.
 Default: 5000 (in milliseconds).
 .El

--- a/src/kern/npf_conn.c
+++ b/src/kern/npf_conn.c
@@ -97,7 +97,7 @@
  *
  * Lock order
  *
- *	npf_config_lock ->
+ *	npf_t::config_lock ->
  *		conn_lock ->
  *			npf_conn_t::c_lock
  */

--- a/src/kern/npf_ext_normalize.c
+++ b/src/kern/npf_ext_normalize.c
@@ -114,7 +114,7 @@ npf_normalize_ip4(npf_cache_t *npc, npf_normalize_t *np)
 	if (np->n_random_id) {
 		uint16_t oid = ip->ip_id, nid;
 
-		nid = htons(ip_randomid(ip_ids, 0));
+		nid = ip_randomid();
 		cksum = npf_fixup16_cksum(cksum, oid, nid);
 		ip->ip_id = nid;
 	}

--- a/src/kern/npf_tableset.c
+++ b/src/kern/npf_tableset.c
@@ -101,7 +101,7 @@ struct npf_table {
 
 	/*
 	 * Table ID, type and lock.  The ID may change during the
-	 * config reload, it is protected by the npf_config_lock.
+	 * config reload, it is protected by the npf_t::config_lock.
 	 */
 	int			t_type;
 	unsigned		t_id;

--- a/src/kern/npf_worker.c
+++ b/src/kern/npf_worker.c
@@ -271,7 +271,7 @@ npf_worker(void *arg)
 	npf_t *npf;
 
 	mutex_enter(&winfo->lock);
-	while (!winfo->exit) {
+	for (;;) {
 		unsigned wait_time = NPF_GC_MAXWAIT;
 
 		/*

--- a/src/kern/stand/npf_stand.h
+++ b/src/kern/stand/npf_stand.h
@@ -349,7 +349,7 @@ npfkern_percpu_foreach(percpu_t *pc, percpu_callback_t cb, void *arg)
  */
 
 #define	cprng_fast32()			((uint32_t)random())
-#define	ip_randomid(o,s)		((uint16_t)random())
+#define	ip_randomid()			((uint16_t)random())
 
 /*
  * Hashing.

--- a/src/npftest/libnpftest/npf_gc_test.c
+++ b/src/npftest/libnpftest/npf_gc_test.c
@@ -222,7 +222,7 @@ run_worker_tests(npf_t *npf)
 		/* Wait for the task to be done. */
 		while (!atomic_load_acquire(&task_done) && retry--) {
 			npf_worker_signal(test_npf);
-			kpause("gctest", false, mstohz(1), NULL);
+			kpause("gctest", false, MAX(1, mstohz(1)), NULL);
 		}
 
 		CHECK_TRUE(atomic_load_acquire(&task_done));


### PR DESCRIPTION
- npf_dev_ioctl: add missing cases; from maxv at netbsd org.

- npf_dev_ioctl: do not silently ignore the errors from npfctl_run_op()
as it can cause errors with npfctl; from christos at netbsd org.

- npf_autounload_p: call npf_default_pass() with the config lock
and fix some comments; from christos at netbsd org.

- npf_worker: do not stop early after sleeping and before processing
instances; from riastradh at netbsd org.

- npf-params(7): fix a typo for gc.interval_max; from taca at netbsd org.

- npf_normalize_ip4: just sync ip_randomid() with NetBSD's API.