### PR TITLE
Drop table lock around copyout.

### DIFF
--- a/src/kern/npf_tableset.c
+++ b/src/kern/npf_tableset.c
@@ -736,15 +736,17 @@ table_ent_copyout(const npf_addr_t *addr, const int alen, npf_netmask_t mask,
 }
 
 static int
-table_generic_list(const npf_table_t *t, void *ubuf, size_t len)
+table_generic_list(npf_table_t *t, void *ubuf, size_t len)
 {
 	npf_tblent_t *ent;
 	size_t off = 0;
 	int error = 0;
 
 	LIST_FOREACH(ent, &t->t_list, te_listent) {
+		mutex_exit(&t->t_lock);
 		error = table_ent_copyout(&ent->te_addr,
 		    ent->te_alen, ent->te_preflen, ubuf, len, &off);
+		mutex_enter(&t->t_lock);
 		if (error)
 			break;
 	}


### PR DESCRIPTION
It is forbidden to hold a spin lock around copyout, and t_lock is a spin lock.

We need t_lock in order to iterate over the list of entries. However, during copyout itself, we only need to ensure that the object we're copying out isn't freed by npf_table_remove or npf_table_gc.

Fortunately, the only caller of npf_table_list, npf_table_remove, and npf_table_gc is npfctl_table, and it serializes all of them by the npf config lock.  So we can safely drop t_lock across copyout.

https://gnats.NetBSD.org/57136
https://gnats.NetBSD.org/57181