### PR TITLE
Use store-release, load-consume operations.

### DIFF
--- a/src/kern/npf_conf.c
+++ b/src/kern/npf_conf.c
@@ -131,8 +131,7 @@ npf_config_load(npf_t *npf, npf_config_t *nc, npf_conndb_t *conns, bool flush)
 	/*
 	 * Set the new config and release the lock.
 	 */
-	membar_sync();
-	atomic_store_relaxed(&npf->config, nc);
+	atomic_store_release(&npf->config, nc);
 	if (onc == NULL) {
 		/* Initial load, done. */
 		npf_ifmap_flush(npf);
@@ -225,7 +224,7 @@ npf_config_read_exit(npf_t *npf, int s)
 npf_ruleset_t *
 npf_config_ruleset(npf_t *npf)
 {
-	npf_config_t *config = atomic_load_relaxed(&npf->config);
+	npf_config_t *config = atomic_load_consume(&npf->config);
 	KASSERT(npf_config_locked_p(npf) || npf_ebr_incrit_p(npf->ebr));
 	return config->ruleset;
 }
@@ -233,7 +232,7 @@ npf_config_ruleset(npf_t *npf)
 npf_ruleset_t *
 npf_config_natset(npf_t *npf)
 {
-	npf_config_t *config = atomic_load_relaxed(&npf->config);
+	npf_config_t *config = atomic_load_consume(&npf->config);
 	KASSERT(npf_config_locked_p(npf) || npf_ebr_incrit_p(npf->ebr));
 	return config->nat_ruleset;
 }
@@ -241,7 +240,7 @@ npf_config_natset(npf_t *npf)
 npf_tableset_t *
 npf_config_tableset(npf_t *npf)
 {
-	npf_config_t *config = atomic_load_relaxed(&npf->config);
+	npf_config_t *config = atomic_load_consume(&npf->config);
 	KASSERT(npf_config_locked_p(npf) || npf_ebr_incrit_p(npf->ebr));
 	return config->tableset;
 }
@@ -249,7 +248,7 @@ npf_config_tableset(npf_t *npf)
 bool
 npf_default_pass(npf_t *npf)
 {
-	npf_config_t *config = atomic_load_relaxed(&npf->config);
+	npf_config_t *config = atomic_load_consume(&npf->config);
 	KASSERT(npf_config_locked_p(npf) || npf_ebr_incrit_p(npf->ebr));
 	return config->default_pass;
 }

--- a/src/kern/npf_ifaddr.c
+++ b/src/kern/npf_ifaddr.c
@@ -65,8 +65,10 @@ out:
 static void
 replace_ifnet_table(npf_t *npf, npf_table_t *newt)
 {
-	npf_tableset_t *ts = npf->config->tableset;
+	npf_tableset_t *ts = atomic_load_relaxed(&npf->config)->tableset;
 	npf_table_t *oldt;
+
+	KASSERT(npf_config_locked_p(npf));
 
 	KERNEL_UNLOCK_ONE(NULL);
 

--- a/src/kern/stand/npf_stand.h
+++ b/src/kern/stand/npf_stand.h
@@ -154,6 +154,8 @@ again:
 
 #define	atomic_load_acquire(x)		\
     atomic_load_explicit((x), memory_order_acquire)
+#define	atomic_load_consume(x)		\
+    atomic_load_explicit((x), memory_order_consume)
 #define	atomic_store_release(x, y)	\
     atomic_store_explicit((x), (y), memory_order_release)
 


### PR DESCRIPTION
For data structures that are published and concurrently consumed without a lock, use store-release to publish and load-consume to use.

- No need for membar_sync: none of this stuff requires store-before-load ordering; no Dekker's algorithms here.
- Although load-relaxed technically suffices on most machines you probably care about, keeping the store-release matched with load-consume instead of load-relaxed makes auditing the matching ordered memory operations easier.