### PR TITLE
Drop redundant NULL check before m_freem(9)

### DIFF
--- a/src/kern/npf_handler.c
+++ b/src/kern/npf_handler.c
@@ -306,10 +306,9 @@ out:
 		error = ENETUNREACH;
 	}
 
-	if (*mp) {
-		/* Free the mbuf chain. */
-		m_freem(*mp);
-		*mp = NULL;
-	}
+	/* Free the mbuf chain. */
+	m_freem(*mp);
+	*mp = NULL;
+
 	return error;
 }

--- a/src/npftest/libnpftest/npf_mbuf_subr.c
+++ b/src/npftest/libnpftest/npf_mbuf_subr.c
@@ -73,12 +73,12 @@ npfkern_m_freem(struct mbuf *m)
 #ifdef _NPF_STANDALONE
 	struct mbuf *n;
 
-	do {
+	while (m) {
 		n = m->m_next;
 		m->m_type = MT_FREE;
 		free(m);
 		m = n;
-	} while (m);
+	};
 #else
 	m_freem(m);
 #endif

--- a/src/npftest/libnpftest/npf_nat_test.c
+++ b/src/npftest/libnpftest/npf_nat_test.c
@@ -235,9 +235,7 @@ npf_nat_test(bool verbose)
 		    t->src, t->dst, t->sport, t->dport);
 		error = npfk_packet_handler(npf, &m, ifp, t->di);
 		ret = checkresult(verbose, i, m, ifp, error);
-		if (m) {
-			m_freem(m);
-		}
+		m_freem(m);
 		CHECK_TRUE(ret);
 	}
 	return true;

--- a/src/npftest/libnpftest/npf_rule_test.c
+++ b/src/npftest/libnpftest/npf_rule_test.c
@@ -93,9 +93,7 @@ run_handler_testcase(unsigned i)
 
 	m = mbuf_get_pkt(AF_INET, IPPROTO_UDP, t->src, t->dst, 9000, 9000);
 	error = npfk_packet_handler(npf, &m, ifp, t->di);
-	if (m) {
-		m_freem(m);
-	}
+	m_freem(m);
 	return error;
 }
 


### PR DESCRIPTION
For NetBSD, we are dropping redundant NULL check before m_freem(9), which improves code readability a little bit;
m_freem(9) has accepted NULL argument at least since 4.2BSD. 

For NPF, standalone version of m_freem(9), `npfkern_m_freem()`, does not work for NULL input.

This PR fixes `npfkern_m_freem()` to accept NULL. Then, drop NULL check before m_freem(9) as done for NetBSD.